### PR TITLE
Search Downloads and calendar, themed icons, PiP, and keyboard/tablet polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ Android app that lets you search everything on your phone and on the web, and op
 ## Features
 
 - **Direct keyboard access** - Your homescreen now has a keyboard!
-- **Search everything on your phone** - Apps, their shortcuts, device settings, sorted smartly by usage.
+- **Search everything on your phone** - Apps, their shortcuts, device settings, downloads, upcoming calendar events, sorted smartly by usage.
 - **Search everything on the web** - Youtube, google, bing, maps, spotify... Or add your own custom shortcuts!
-- **Built-in ad-free browser** - Opens web results in-app, blocking ads and trackers by default. Browse privately in an isolated window.
+- **Built-in ad-free browser** - Opens web results in-app, blocking ads and trackers by default. Browse privately in an isolated window. File uploads, picture-in-picture video, and hardware-keyboard shortcuts are included.
 - **Tabs at your thumb** - Swipe the search bar sideways to switch tabs, or up to see them all as live previews. Both work from the home screen too: swipe sideways to drop straight back into your last tab.
 - **Bookmarks & history** - Save any page under a title you choose, then find it back from the search bar. Pages you visit are searchable too, and both show the site's icon.
 - **Speed** - Lightweight, fast!
 - **Swipe Wallpapers** - Your background is an interactive picture album.
 - **Smart input** - Recognizes phone numbers, emails, calculator queries, and web addresses.
-- **App icons history & favorites** - Recently used & favorited apps are shown above the search bar
+- **App icons history & favorites** - Recently used & favorited apps are shown above the search bar. Optional themed (monochrome) icons match the theme; SearchLauncher's own icon can be themed by Android too.
+- **Follows the wallpaper** - Theme color can track the wallpaper behind the search bar (on by default).
 - **Widgets** - Add widgets through the search bar, resize them, and toggle visibility by tapping the background
 - **Voice search** - Tap the mic to speak your query
 - **Snippets** - Fast access to frequently used text snippets
@@ -54,6 +55,8 @@ Android app that lets you search everything on your phone and on the web, and op
 - Permissions:
   - Usage stats (optional, for smart app sorting)
   - Contacts (optional, for contact search)
+  - Calendar (optional, for events in the next week)
+  - Photos / media (optional, for wallpaper import and media in Downloads)
 
 ## Building
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -34,6 +35,8 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
@@ -64,6 +67,8 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:supportsPictureInPicture="true"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
             android:theme="@style/Theme.SearchLauncher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -90,6 +95,7 @@
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
             android:exported="true"
             android:launchMode="singleTask"
+            android:supportsPictureInPicture="true"
             android:taskAffinity="com.searchlauncher.app.browser"
             android:theme="@style/Theme.SearchLauncher.Browser"
             android:windowSoftInputMode="adjustResize">

--- a/app/src/main/java/com/searchlauncher/app/data/CalendarIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/CalendarIndexer.kt
@@ -1,0 +1,157 @@
+package com.searchlauncher.app.data
+
+import android.content.ContentUris
+import android.content.Context
+import android.provider.CalendarContract
+import java.util.Calendar
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+/**
+ * Builds AppSearch documents for calendar instances in the near future.
+ *
+ * Recurring events are expanded through [CalendarContract.Instances], so "standup every weekday"
+ * yields the occurrences that actually fall in the window rather than a single master event.
+ * Persisting the documents (and checking READ_CALENDAR) is the caller's responsibility.
+ */
+class CalendarIndexer(private val context: Context) {
+
+  fun readFingerprint(): String? {
+    return try {
+      val entries = queryEntries()
+      if (entries.isEmpty()) "0/0" else "${entries.size}/${entries.maxOf { it.beginMillis }}"
+    } catch (e: Exception) {
+      android.util.Log.w(TAG, "Failed to read calendar fingerprint", e)
+      null
+    }
+  }
+
+  suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+    val entries = queryEntries()
+    val docs = ArrayList<AppSearchDocument>(entries.size)
+    for (entry in entries) {
+      pauseCheck()
+      docs.add(documentFrom(entry))
+    }
+    return docs
+  }
+
+  internal fun documentFrom(entry: CalendarEntry): AppSearchDocument {
+    val eventUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, entry.eventId)
+    val subtitle = formatSubtitle(entry)
+    val extra = listOfNotNull(entry.location, entry.calendarName).joinToString(" ")
+    return AppSearchDocument(
+      namespace = NAMESPACE,
+      id = "${entry.eventId}/${entry.beginMillis}",
+      name = entry.title,
+      score = 3,
+      intentUri = eventUri.toString(),
+      description = "$subtitle${if (extra.isNotEmpty()) " $extra" else ""}",
+    )
+  }
+
+  private fun queryEntries(): List<CalendarEntry> {
+    val now = System.currentTimeMillis()
+    val end = now + WINDOW_MS
+    val projection =
+      arrayOf(
+        CalendarContract.Instances.EVENT_ID,
+        CalendarContract.Instances.TITLE,
+        CalendarContract.Instances.BEGIN,
+        CalendarContract.Instances.ALL_DAY,
+        CalendarContract.Instances.EVENT_LOCATION,
+        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+      )
+    val cursor =
+      try {
+        CalendarContract.Instances.query(context.contentResolver, projection, now, end)
+      } catch (e: SecurityException) {
+        android.util.Log.w(TAG, "READ_CALENDAR denied", e)
+        null
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed querying calendar instances", e)
+        null
+      } ?: return emptyList()
+
+    val out = ArrayList<CalendarEntry>(MAX_EVENTS)
+    cursor.use {
+      val idIdx = it.getColumnIndex(CalendarContract.Instances.EVENT_ID)
+      val titleIdx = it.getColumnIndex(CalendarContract.Instances.TITLE)
+      val beginIdx = it.getColumnIndex(CalendarContract.Instances.BEGIN)
+      val allDayIdx = it.getColumnIndex(CalendarContract.Instances.ALL_DAY)
+      val locationIdx = it.getColumnIndex(CalendarContract.Instances.EVENT_LOCATION)
+      val calIdx = it.getColumnIndex(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
+      if (idIdx < 0 || beginIdx < 0) return emptyList()
+
+      while (it.moveToNext() && out.size < MAX_EVENTS) {
+        val title = (if (titleIdx >= 0) it.getString(titleIdx) else null)?.trim().orEmpty()
+        val eventId = it.getLong(idIdx)
+        if (eventId <= 0L) continue
+        out.add(
+          CalendarEntry(
+            eventId = eventId,
+            title = title.ifBlank { "(No title)" },
+            beginMillis = it.getLong(beginIdx),
+            allDay = allDayIdx >= 0 && it.getInt(allDayIdx) == 1,
+            calendarName =
+              if (calIdx >= 0) it.getString(calIdx)?.takeIf { n -> n.isNotBlank() } else null,
+            location =
+              if (locationIdx >= 0) it.getString(locationIdx)?.takeIf { n -> n.isNotBlank() }
+              else null,
+          )
+        )
+      }
+    }
+    return out
+  }
+
+  companion object {
+    const val NAMESPACE = "calendar"
+    /** Today plus a week, with a little slack so Sunday-evening planning still finds Monday. */
+    const val WINDOW_MS = 8L * 24 * 60 * 60 * 1000
+    const val MAX_EVENTS = 200
+    private const val TAG = "CalendarIndexer"
+
+    fun formatSubtitle(entry: CalendarEntry, nowMillis: Long = System.currentTimeMillis()): String {
+      val whenText = formatWhen(entry.beginMillis, entry.allDay, nowMillis)
+      return listOfNotNull(whenText, entry.location, entry.calendarName).joinToString(" · ")
+    }
+
+    fun formatWhen(beginMillis: Long, allDay: Boolean, nowMillis: Long): String {
+      val startOfToday = startOfDay(nowMillis)
+      val startOfTarget = startOfDay(beginMillis)
+      val dayDelta = TimeUnit.MILLISECONDS.toDays(startOfTarget - startOfToday)
+      val dayLabel =
+        when (dayDelta) {
+          0L -> "Today"
+          1L -> "Tomorrow"
+          else -> {
+            val fmt = java.text.SimpleDateFormat("EEE d MMM", Locale.getDefault())
+            fmt.format(java.util.Date(beginMillis))
+          }
+        }
+      if (allDay) return "$dayLabel · All day"
+      val timeFmt = java.text.SimpleDateFormat("HH:mm", Locale.US)
+      return "$dayLabel · ${timeFmt.format(java.util.Date(beginMillis))}"
+    }
+
+    private fun startOfDay(millis: Long): Long {
+      val cal = Calendar.getInstance()
+      cal.timeInMillis = millis
+      cal.set(Calendar.HOUR_OF_DAY, 0)
+      cal.set(Calendar.MINUTE, 0)
+      cal.set(Calendar.SECOND, 0)
+      cal.set(Calendar.MILLISECOND, 0)
+      return cal.timeInMillis
+    }
+  }
+}
+
+data class CalendarEntry(
+  val eventId: Long,
+  val title: String,
+  val beginMillis: Long,
+  val allDay: Boolean,
+  val calendarName: String?,
+  val location: String?,
+)

--- a/app/src/main/java/com/searchlauncher/app/data/DownloadIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/DownloadIndexer.kt
@@ -1,0 +1,224 @@
+package com.searchlauncher.app.data
+
+import android.content.ContentUris
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+/**
+ * Builds AppSearch documents for files in the device Downloads folder.
+ *
+ * This is a pure reader: it queries [MediaStore] and returns documents. Persisting them (and
+ * checking storage/media permissions) is the caller's responsibility.
+ *
+ * On Android 13+ the platform only surfaces media the app has been granted, plus files this app
+ * itself downloaded. PDFs and other documents from other apps need the All files access permission,
+ * which this indexer does not request.
+ */
+class DownloadIndexer(private val context: Context) {
+
+  fun readFingerprint(): String? {
+    return try {
+      val entries = queryEntries()
+      if (entries.isEmpty()) "0/0"
+      else "${entries.size}/${entries.maxOf { it.dateModifiedSeconds }}"
+    } catch (e: Exception) {
+      android.util.Log.w(TAG, "Failed to read downloads fingerprint", e)
+      null
+    }
+  }
+
+  suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+    val entries = queryEntries()
+    val docs = ArrayList<AppSearchDocument>(entries.size)
+    for (entry in entries) {
+      pauseCheck()
+      docs.add(documentFrom(entry))
+    }
+    return docs
+  }
+
+  internal fun documentFrom(entry: DownloadEntry): AppSearchDocument {
+    val uri = ContentUris.withAppendedId(entry.collectionUri, entry.id)
+    val subtitle = formatSubtitle(entry)
+    return AppSearchDocument(
+      namespace = NAMESPACE,
+      id = entry.id.toString(),
+      name = entry.displayName,
+      score = 3,
+      intentUri = uri.toString(),
+      description = "${entry.mimeType.orEmpty()}|$subtitle",
+    )
+  }
+
+  private fun queryEntries(): List<DownloadEntry> {
+    val seen = HashSet<Long>()
+    val out = ArrayList<DownloadEntry>(MAX_FILES)
+    collectFrom(
+      uri = MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+      extraSelection = null,
+      extraArgs = null,
+      seen = seen,
+      out = out,
+    )
+    if (out.size < MAX_FILES) {
+      collectFrom(
+        uri = MediaStore.Files.getContentUri("external"),
+        extraSelection =
+          "(${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ? OR ${MediaStore.MediaColumns.RELATIVE_PATH} = ?)",
+        extraArgs = arrayOf("Download/%", "Download/"),
+        seen = seen,
+        out = out,
+      )
+    }
+    return out
+  }
+
+  private fun collectFrom(
+    uri: android.net.Uri,
+    extraSelection: String?,
+    extraArgs: Array<String>?,
+    seen: MutableSet<Long>,
+    out: MutableList<DownloadEntry>,
+  ) {
+    if (out.size >= MAX_FILES) return
+    val remaining = MAX_FILES - out.size
+    val pendingClause =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        "${MediaStore.MediaColumns.IS_PENDING}=0"
+      } else {
+        null
+      }
+    val selection =
+      listOfNotNull(pendingClause, extraSelection).joinToString(" AND ").ifEmpty { null }
+    val projection =
+      arrayOf(
+        MediaStore.MediaColumns._ID,
+        MediaStore.MediaColumns.DISPLAY_NAME,
+        MediaStore.MediaColumns.MIME_TYPE,
+        MediaStore.MediaColumns.DATE_MODIFIED,
+        MediaStore.MediaColumns.SIZE,
+      )
+    val sort = "${MediaStore.MediaColumns.DATE_MODIFIED} DESC"
+    val cursor =
+      try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          val args =
+            Bundle().apply {
+              putInt(android.content.ContentResolver.QUERY_ARG_LIMIT, remaining)
+              putString(android.content.ContentResolver.QUERY_ARG_SQL_SORT_ORDER, sort)
+              if (selection != null) {
+                putString(android.content.ContentResolver.QUERY_ARG_SQL_SELECTION, selection)
+                extraArgs?.let {
+                  putStringArray(android.content.ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, it)
+                }
+              }
+            }
+          context.contentResolver.query(uri, projection, args, null)
+        } else {
+          context.contentResolver.query(
+            uri,
+            projection,
+            selection,
+            extraArgs,
+            "$sort LIMIT $remaining",
+          )
+        }
+      } catch (e: SecurityException) {
+        android.util.Log.w(TAG, "No access to $uri", e)
+        null
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed querying $uri", e)
+        null
+      } ?: return
+
+    cursor.use {
+      val idIdx = it.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+      val nameIdx = it.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+      val mimeIdx = it.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)
+      val modifiedIdx = it.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED)
+      val sizeIdx = it.getColumnIndex(MediaStore.MediaColumns.SIZE)
+      while (it.moveToNext() && out.size < MAX_FILES) {
+        val id = it.getLong(idIdx)
+        if (!seen.add(id)) continue
+        val name = it.getString(nameIdx)?.takeIf { n -> n.isNotBlank() } ?: continue
+        out.add(
+          DownloadEntry(
+            id = id,
+            displayName = name,
+            mimeType = if (mimeIdx >= 0) it.getString(mimeIdx) else null,
+            dateModifiedSeconds =
+              if (modifiedIdx >= 0 && !it.isNull(modifiedIdx)) it.getLong(modifiedIdx) else 0L,
+            sizeBytes = if (sizeIdx >= 0 && !it.isNull(sizeIdx)) it.getLong(sizeIdx) else 0L,
+            collectionUri = uri,
+          )
+        )
+      }
+    }
+  }
+
+  companion object {
+    const val NAMESPACE = "downloads"
+    const val MAX_FILES = 400
+    private const val TAG = "DownloadIndexer"
+
+    fun formatSubtitle(entry: DownloadEntry): String {
+      val size = formatSize(entry.sizeBytes)
+      val whenText = formatModified(entry.dateModifiedSeconds)
+      val kind = mimeLabel(entry.mimeType)
+      return listOfNotNull(kind, size, whenText).joinToString(" · ")
+    }
+
+    fun mimeLabel(mime: String?): String? {
+      if (mime.isNullOrBlank()) return null
+      return when {
+        mime.startsWith("image/") -> "Image"
+        mime.startsWith("video/") -> "Video"
+        mime.startsWith("audio/") -> "Audio"
+        mime == "application/pdf" -> "PDF"
+        mime.contains("zip") || mime.contains("compressed") -> "Archive"
+        mime.startsWith("text/") -> "Text"
+        else -> mime.substringAfter('/', mime).uppercase(Locale.US)
+      }
+    }
+
+    fun formatSize(bytes: Long): String? {
+      if (bytes <= 0L) return null
+      if (bytes < 1024) return "$bytes B"
+      val kb = bytes / 1024.0
+      if (kb < 1024) return String.format(Locale.US, "%.0f KB", kb)
+      val mb = kb / 1024.0
+      return if (mb < 1024) String.format(Locale.US, "%.1f MB", mb)
+      else String.format(Locale.US, "%.1f GB", mb / 1024.0)
+    }
+
+    fun formatModified(epochSeconds: Long): String? {
+      if (epochSeconds <= 0L) return null
+      val then = TimeUnit.SECONDS.toMillis(epochSeconds)
+      val delta = System.currentTimeMillis() - then
+      val days = TimeUnit.MILLISECONDS.toDays(delta)
+      return when {
+        delta < TimeUnit.HOURS.toMillis(1) -> "Just now"
+        delta < TimeUnit.DAYS.toMillis(1) -> "${TimeUnit.MILLISECONDS.toHours(delta)}h ago"
+        days == 1L -> "Yesterday"
+        days < 7 -> "${days}d ago"
+        else -> {
+          val fmt = java.text.SimpleDateFormat("d MMM", Locale.getDefault())
+          fmt.format(java.util.Date(then))
+        }
+      }
+    }
+  }
+}
+
+data class DownloadEntry(
+  val id: Long,
+  val displayName: String,
+  val mimeType: String?,
+  val dateModifiedSeconds: Long,
+  val sizeBytes: Long,
+  val collectionUri: android.net.Uri = MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+)

--- a/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
@@ -17,6 +17,8 @@ object FavoriteKeys {
       "snippets",
       "web_bookmarks",
       "web_saved",
+      "downloads",
+      "calendar",
     )
 
   fun of(namespace: String, id: String): String = "$namespace/$id"
@@ -58,7 +60,8 @@ fun SearchResult.isFavoritable(): Boolean =
     is SearchResult.Shortcut,
     is SearchResult.Snippet,
     is SearchResult.SearchIntent -> true
-    is SearchResult.Content -> namespace in setOf("app_shortcuts", "web_saved", "web_bookmarks")
+    is SearchResult.Content ->
+      namespace in setOf("app_shortcuts", "web_saved", "web_bookmarks", "downloads", "calendar")
     // An open tab is a live view of the browser, not a thing to pin: it disappears when closed,
     // which would leave the favorite pointing at nothing.
     is SearchResult.BrowserTab,

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -38,6 +38,8 @@ object Prefs {
     const val OBSERVED_HISTORY_LIMIT = "observed_history_limit"
     const val LAST_REINDEX_TIMESTAMP = "last_reindex_timestamp"
     const val CONTACTS_FINGERPRINT = "contacts_fingerprint"
+    const val CALENDAR_FINGERPRINT = "calendar_fingerprint"
+    const val DOWNLOADS_FINGERPRINT = "downloads_fingerprint"
   }
 
   /** Measured soft-keyboard height, cached to avoid layout jump on the next launch. */

--- a/app/src/main/java/com/searchlauncher/app/data/RankingScores.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/RankingScores.kt
@@ -6,8 +6,9 @@ package com.searchlauncher.app.data
  * Final ordering is by [SearchResult.rankingScore] descending. Two paths feed it:
  * 1. Direct scores - smart actions, custom shortcuts, suggestions, widgets: a literal value chosen
  *    so the result lands at the desired position.
- * 2. Indexed scores - apps, app_shortcuts, snippets, shortcuts, contacts, web_saved, web_bookmarks:
- *    FuzzyMatch.calculateScore (0..100) + a namespace boost + optional context boost + usage.
+ * 2. Indexed scores - apps, app_shortcuts, snippets, shortcuts, contacts, calendar, downloads,
+ *    web_saved, web_bookmarks: FuzzyMatch.calculateScore (0..100) + a namespace boost + optional
+ *    context boost + usage.
  *
  * Approximate descending order of typical scores: 1600 timer smart action; 1200 custom shortcut
  * with explicit search term ("g cats"); ~450-480 a page open in the browser; ~150-250 indexed hits,
@@ -71,6 +72,8 @@ object RankingScores {
   const val NAMESPACE_BOOST_WEB_BOOKMARKS = 80
   const val NAMESPACE_BOOST_SHORTCUTS = 70
   const val NAMESPACE_BOOST_CONTACTS = 40
+  const val NAMESPACE_BOOST_CALENDAR = 90
+  const val NAMESPACE_BOOST_DOWNLOADS = 50
   const val NAMESPACE_BOOST_DEFAULT = 0
 
   // --- Context boosts stacked on top of the namespace boost ---

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
@@ -95,6 +95,8 @@ object SearchRanker {
         5 -> RankingScores.NAMESPACE_BOOST_CONTACTS
         8 -> RankingScores.NAMESPACE_BOOST_SNIPPETS
         9 -> RankingScores.NAMESPACE_BOOST_WEB_SAVED
+        10 -> RankingScores.NAMESPACE_BOOST_DOWNLOADS
+        11 -> RankingScores.NAMESPACE_BOOST_CALENDAR
         else -> RankingScores.NAMESPACE_BOOST_DEFAULT
       }
 

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.provider.CalendarContract
 import android.provider.ContactsContract
+import android.provider.MediaStore
 import android.util.Log
 import androidx.appsearch.app.AppSearchSession
 import androidx.appsearch.app.PutDocumentsRequest
@@ -53,6 +55,8 @@ private const val APPS_REFRESH_DEBOUNCE_MS = 750L
 
 /** Editing one contact fires several provider notifications; wait for the burst to settle. */
 private const val CONTACTS_REFRESH_DEBOUNCE_MS = 2000L
+private const val CALENDAR_REFRESH_DEBOUNCE_MS = 1500L
+private const val DOWNLOADS_REFRESH_DEBOUNCE_MS = 1500L
 
 data class SearchableDocument(
   val doc: AppSearchDocument,
@@ -91,7 +95,12 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   internal fun wrap(doc: AppSearchDocument): SearchableDocument {
     val searchableText =
-      if (doc.namespace == "snippets" || doc.namespace == "app_shortcuts") {
+      if (
+        doc.namespace == "snippets" ||
+          doc.namespace == "app_shortcuts" ||
+          doc.namespace == "downloads" ||
+          doc.namespace == "calendar"
+      ) {
         listOf(doc.name, doc.description.orEmpty()).joinToString(" ")
       } else {
         doc.name
@@ -112,6 +121,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         "search_shortcuts" -> 7
         "snippets" -> 8
         "web_saved" -> 9
+        "downloads" -> 10
+        "calendar" -> 11
         else -> 0
       }
 
@@ -278,6 +289,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private val shortcutIndexer = ShortcutIndexer(context)
   private val contactIndexer = ContactIndexer(context)
   private val snippetIndexer = SnippetIndexer(context)
+  private val downloadIndexer = DownloadIndexer(context)
+  private val calendarIndexer = CalendarIndexer(context)
 
   private val _isInitialized = kotlinx.coroutines.flow.MutableStateFlow(false)
   val isInitialized: kotlinx.coroutines.flow.StateFlow<Boolean> = _isInitialized
@@ -355,6 +368,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           )
 
           registerContactsObserver()
+          registerCalendarObserver()
+          registerDownloadsObserver()
 
           // Pre-cache SearchLauncher's own icon for internal actions
           scope.launch {
@@ -452,6 +467,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             // Contacts can change while we aren't running, so the freshness window alone would
             // hide added/removed contacts for hours. Cheap fingerprint check catches that.
             refreshContactsIfChanged()
+            refreshCalendarIfChanged()
+            refreshDownloadsIfChanged()
             return@launch
           }
 
@@ -485,6 +502,22 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               android.util.Log.d(
                 "SearchRepository",
                 "indexContacts took ${System.currentTimeMillis() - contactsStart}ms",
+              )
+
+              val calendarStart = System.currentTimeMillis()
+              pauseIndexingIfSearchIsActive()
+              indexCalendar()
+              android.util.Log.d(
+                "SearchRepository",
+                "indexCalendar took ${System.currentTimeMillis() - calendarStart}ms",
+              )
+
+              val downloadsStart = System.currentTimeMillis()
+              pauseIndexingIfSearchIsActive()
+              indexDownloads()
+              android.util.Log.d(
+                "SearchRepository",
+                "indexDownloads took ${System.currentTimeMillis() - downloadsStart}ms",
               )
 
               val snippetsStart = System.currentTimeMillis()
@@ -895,6 +928,153 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
     }
 
+  /** Coalesces calendar provider bursts into one rebuild. */
+  private var calendarRefreshJob: kotlinx.coroutines.Job? = null
+
+  private val calendarObserver =
+    object :
+      android.database.ContentObserver(android.os.Handler(android.os.Looper.getMainLooper())) {
+      override fun onChange(selfChange: Boolean) = onChange(selfChange, null)
+
+      override fun onChange(selfChange: Boolean, uri: android.net.Uri?) {
+        calendarRefreshJob?.cancel()
+        calendarRefreshJob =
+          scope.launch {
+            delay(CALENDAR_REFRESH_DEBOUNCE_MS)
+            android.util.Log.d("SearchRepository", "Calendar changed, re-indexing")
+            refreshCalendar()
+          }
+      }
+    }
+
+  private fun registerCalendarObserver() {
+    try {
+      context.contentResolver.registerContentObserver(
+        CalendarContract.Events.CONTENT_URI,
+        true,
+        calendarObserver,
+      )
+    } catch (e: Exception) {
+      android.util.Log.e("SearchRepository", "Failed to observe calendar", e)
+      Sentry.captureException(e)
+    }
+  }
+
+  private suspend fun refreshCalendar() {
+    indexWriteMutex.withLock { indexCalendar() }
+    saveFastIndexCache()
+    _indexUpdated.emit(Unit)
+  }
+
+  private suspend fun refreshCalendarIfChanged() =
+    withContext(Dispatchers.IO) {
+      if (
+        context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR) !=
+          android.content.pm.PackageManager.PERMISSION_GRANTED
+      ) {
+        return@withContext
+      }
+      val fingerprint = calendarIndexer.readFingerprint() ?: return@withContext
+      val prefs = context.getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      if (fingerprint == prefs.getString(Prefs.Launcher.CALENDAR_FINGERPRINT, null))
+        return@withContext
+
+      android.util.Log.d("SearchRepository", "Calendar changed while away, re-indexing")
+      refreshCalendar()
+    }
+
+  suspend fun indexCalendar() =
+    withContext(IndexingDispatchers.limited) {
+      pauseIndexingIfSearchIsActive()
+      val session = appSearchSession ?: return@withContext
+      val permission = context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)
+      if (permission != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+        android.util.Log.w("SearchRepository", "READ_CALENDAR permission denied")
+        removeMissingDocuments(session, CalendarIndexer.NAMESPACE, emptySet())
+        replaceCollection(CalendarIndexer.NAMESPACE, emptyList())
+        return@withContext
+      }
+      android.util.Log.d("SearchRepository", "Indexing calendar...")
+      val fingerprint = calendarIndexer.readFingerprint()
+      val events = calendarIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
+      android.util.Log.d("SearchRepository", "Indexed ${events.size} calendar events")
+      putDocuments(session, events)
+      removeMissingDocuments(session, CalendarIndexer.NAMESPACE, events.map { it.id }.toSet())
+      replaceCollection(CalendarIndexer.NAMESPACE, events)
+      context
+        .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+        .edit()
+        .putString(Prefs.Launcher.CALENDAR_FINGERPRINT, fingerprint)
+        .apply()
+    }
+
+  /** MediaStore notifies often during a download; wait for the burst to settle. */
+  private var downloadsRefreshJob: kotlinx.coroutines.Job? = null
+
+  private val downloadsObserver =
+    object :
+      android.database.ContentObserver(android.os.Handler(android.os.Looper.getMainLooper())) {
+      override fun onChange(selfChange: Boolean) = onChange(selfChange, null)
+
+      override fun onChange(selfChange: Boolean, uri: android.net.Uri?) {
+        downloadsRefreshJob?.cancel()
+        downloadsRefreshJob =
+          scope.launch {
+            delay(DOWNLOADS_REFRESH_DEBOUNCE_MS)
+            android.util.Log.d("SearchRepository", "Downloads changed, re-indexing")
+            refreshDownloads()
+          }
+      }
+    }
+
+  private fun registerDownloadsObserver() {
+    try {
+      context.contentResolver.registerContentObserver(
+        MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+        true,
+        downloadsObserver,
+      )
+    } catch (e: Exception) {
+      android.util.Log.e("SearchRepository", "Failed to observe downloads", e)
+      Sentry.captureException(e)
+    }
+  }
+
+  private suspend fun refreshDownloads() {
+    indexWriteMutex.withLock { indexDownloads() }
+    saveFastIndexCache()
+    _indexUpdated.emit(Unit)
+  }
+
+  private suspend fun refreshDownloadsIfChanged() =
+    withContext(Dispatchers.IO) {
+      val fingerprint = downloadIndexer.readFingerprint() ?: return@withContext
+      val prefs = context.getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      if (fingerprint == prefs.getString(Prefs.Launcher.DOWNLOADS_FINGERPRINT, null))
+        return@withContext
+
+      android.util.Log.d("SearchRepository", "Downloads changed while away, re-indexing")
+      refreshDownloads()
+    }
+
+  suspend fun indexDownloads() =
+    withContext(IndexingDispatchers.limited) {
+      pauseIndexingIfSearchIsActive()
+      val session = appSearchSession ?: return@withContext
+      android.util.Log.d("SearchRepository", "Indexing downloads...")
+      val fingerprint = downloadIndexer.readFingerprint()
+      val files = downloadIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
+      android.util.Log.d("SearchRepository", "Indexed ${files.size} downloads")
+      putDocuments(session, files)
+      removeMissingDocuments(session, DownloadIndexer.NAMESPACE, files.map { it.id }.toSet())
+      replaceCollection(DownloadIndexer.NAMESPACE, files)
+      context
+        .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+        .edit()
+        .putString(Prefs.Launcher.DOWNLOADS_FINGERPRINT, fingerprint)
+        .apply()
+    }
+
   suspend fun resetIndex() =
     withContext(Dispatchers.IO) {
       if (appSearchSession == null) return@withContext
@@ -918,6 +1098,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           indexApps()
           indexCustomShortcuts()
           indexContacts()
+          indexCalendar()
+          indexDownloads()
           indexSnippets()
         }
 

--- a/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
@@ -42,6 +42,8 @@ class SearchResultFactory(
         createStaticShortcutResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
       "contacts" -> createContactResult(sdoc, rankingScore, query, allowIpc)
       "snippets" -> createSnippetResult(sdoc, rankingScore)
+      "downloads" -> createDownloadResult(sdoc, rankingScore)
+      "calendar" -> createCalendarResult(sdoc, rankingScore)
       else -> createAppResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
     }
   }
@@ -232,6 +234,43 @@ class SearchResultFactory(
       icon = icon,
       alias = doc.id,
       content = doc.description ?: "",
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createDownloadResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+  ): SearchResult.Content {
+    val doc = sdoc.doc
+    val mime = doc.description?.substringBefore("|", "")?.takeIf { it.isNotBlank() }
+    val subtitle =
+      doc.description?.substringAfter("|", "")?.takeIf { it.isNotBlank() } ?: "Download"
+    return SearchResult.Content(
+      id = doc.id,
+      namespace = "downloads",
+      title = doc.name,
+      subtitle = subtitle,
+      icon = context.getDrawable(R.drawable.ic_file),
+      packageName = mime ?: "downloads",
+      deepLink = doc.intentUri,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createCalendarResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+  ): SearchResult.Content {
+    val doc = sdoc.doc
+    return SearchResult.Content(
+      id = doc.id,
+      namespace = "calendar",
+      title = doc.name,
+      subtitle = doc.description ?: "Event",
+      icon = context.getDrawable(R.drawable.ic_event),
+      packageName = "vnd.android.cursor.item/event",
+      deepLink = doc.intentUri,
       rankingScore = rankingScore,
     )
   }

--- a/app/src/main/java/com/searchlauncher/app/data/WallpaperRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/WallpaperRepository.kt
@@ -384,8 +384,14 @@ class WallpaperRepository(private val context: Context) {
           if (!bitmap.isRecycled) bitmap.recycle()
         }
 
-      // Try dominant swatch first, then vibrant, then muted
-      val swatch = palette.dominantSwatch ?: palette.vibrantSwatch ?: palette.mutedSwatch
+      // Vibrant first: "dominant" on a photo is often a muddy grey, which makes auto-from-wallpaper
+      // look like it is doing nothing. Vibrant/muted-vibrant tracks the colour people actually see.
+      val swatch =
+        palette.vibrantSwatch
+          ?: palette.lightVibrantSwatch
+          ?: palette.darkVibrantSwatch
+          ?: palette.dominantSwatch
+          ?: palette.mutedSwatch
 
       if (swatch != null) {
         android.util.Log.d(

--- a/app/src/main/java/com/searchlauncher/app/ui/KeyShortcuts.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/KeyShortcuts.kt
@@ -1,0 +1,37 @@
+package com.searchlauncher.app.ui
+
+import android.view.KeyEvent
+
+/**
+ * Hardware-keyboard shortcuts for the search bar and the in-app browser.
+ *
+ * Ctrl/Cmd chords are matched on [KeyEvent] so they can be intercepted before a WebView eats them.
+ */
+object KeyShortcuts {
+  fun isCtrl(event: KeyEvent): Boolean = event.isCtrlPressed || event.isMetaPressed
+
+  fun matches(
+    event: KeyEvent,
+    keyCode: Int,
+    ctrl: Boolean = false,
+    shift: Boolean = false,
+  ): Boolean {
+    if (event.action != KeyEvent.ACTION_DOWN) return false
+    if (event.keyCode != keyCode) return false
+    if (ctrl != isCtrl(event)) return false
+    if (shift != event.isShiftPressed) return false
+    return !event.isAltPressed
+  }
+}
+
+interface KeyShortcutHost {
+  var keyShortcutHandler: ((KeyEvent) -> Boolean)?
+}
+
+/** Lets the hosted or standalone browser ask the activity to enter PiP for fullscreen video. */
+interface PipCapable {
+  var pipVideoView: android.view.View?
+  var inPictureInPicture: Boolean
+
+  fun enterPipIfEligible(): Boolean
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.withContext
  */
 private data class SavedWallpaper(val uri: String?)
 
-class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
 
   // Export state
   var exportIncludeWallpapers = true
@@ -50,20 +50,24 @@ class MainActivity : ComponentActivity() {
   var showExportDialog by mutableStateOf(false)
   var showImportConfirmation by mutableStateOf(false)
   var pendingImportUri: Uri? = null
+  override var keyShortcutHandler: ((android.view.KeyEvent) -> Boolean)? = null
+  override var pipVideoView: android.view.View? = null
+  override var inPictureInPicture by mutableStateOf(false)
 
   /**
-   * The opening offer of the two optional permissions, and which of them are worth offering.
+   * The opening offer of the optional permissions, and which of them are worth offering.
    *
-   * Both are asked for here rather than where they happen to be needed, because neither was
+   * They are asked for here rather than where they happen to be needed, because they were not
    * reachable before: photo access arrived as a bare system dialog in the first seconds, with
-   * nothing on screen to say what it was for, and contact access was never requested at all — the
-   * app only ever checked it and dropped a hint in the search bar, so the one way to turn contact
-   * search on was to find SearchLauncher in Android's settings. Whatever is missing is explained on
-   * screen first, and the system prompts follow only on yes.
+   * nothing on screen to say what it was for, and contact or calendar access was never requested at
+   * all — the app only ever checked them and dropped a hint in the search bar, so the one way to
+   * turn those searches on was to find SearchLauncher in Android's settings. Whatever is missing is
+   * explained on screen first, and the system prompts follow only on yes.
    */
   var showOnboardingPermissions by mutableStateOf(false)
   var onboardingOffersContacts by mutableStateOf(false)
   var onboardingOffersPhotos by mutableStateOf(false)
+  var onboardingOffersCalendar by mutableStateOf(false)
 
   private val exportBackupLauncher =
     registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) {
@@ -106,9 +110,13 @@ class MainActivity : ComponentActivity() {
       lifecycleScope.launch {
         if (results[android.Manifest.permission.READ_MEDIA_IMAGES] == true) {
           app.wallpaperRepository.addSystemWallpaper()
+          app.searchRepository.indexDownloads()
         }
         if (results[android.Manifest.permission.READ_CONTACTS] == true) {
           app.searchRepository.indexContacts()
+        }
+        if (results[android.Manifest.permission.READ_CALENDAR] == true) {
+          app.searchRepository.indexCalendar()
         }
       }
     }
@@ -535,6 +543,41 @@ class MainActivity : ComponentActivity() {
     }
   }
 
+  override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+    if (keyShortcutHandler?.invoke(event) == true) return true
+    return super.dispatchKeyEvent(event)
+  }
+
+  override fun onUserLeaveHint() {
+    super.onUserLeaveHint()
+    enterPipIfEligible()
+  }
+
+  override fun onPictureInPictureModeChanged(
+    isInPictureInPictureMode: Boolean,
+    newConfig: android.content.res.Configuration,
+  ) {
+    super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+    inPictureInPicture = isInPictureInPictureMode
+  }
+
+  override fun enterPipIfEligible(): Boolean {
+    val view = pipVideoView ?: return false
+    if (isInPictureInPictureMode) return false
+    val width = view.width.coerceAtLeast(16)
+    val height = view.height.coerceAtLeast(9)
+    val params =
+      android.app.PictureInPictureParams.Builder()
+        .setAspectRatio(android.util.Rational(width, height))
+        .build()
+    return try {
+      enterPictureInPictureMode(params)
+    } catch (e: Exception) {
+      android.util.Log.w("MainActivity", "PiP failed", e)
+      false
+    }
+  }
+
   override fun onStart() {
     super.onStart()
     try {
@@ -685,6 +728,9 @@ class MainActivity : ComponentActivity() {
       val contactsGranted =
         context.checkSelfPermission(android.Manifest.permission.READ_CONTACTS) ==
           android.content.pm.PackageManager.PERMISSION_GRANTED
+      val calendarGranted =
+        context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR) ==
+          android.content.pm.PackageManager.PERMISSION_GRANTED
 
       // Nothing to ask about: the wallpaper can just be taken.
       if (managedWallpapers.isEmpty() && photosGranted) {
@@ -697,10 +743,12 @@ class MainActivity : ComponentActivity() {
       // who said no last time, is not asked again.
       val offerPhotos = managedWallpapers.isEmpty() && !photosGranted
       val offerContacts = !contactsGranted
-      if (!onboardingPermissionsAsked && (offerPhotos || offerContacts)) {
+      val offerCalendar = !calendarGranted
+      if (!onboardingPermissionsAsked && (offerPhotos || offerContacts || offerCalendar)) {
         (context as? MainActivity)?.let {
           it.onboardingOffersPhotos = offerPhotos
           it.onboardingOffersContacts = offerContacts
+          it.onboardingOffersCalendar = offerCalendar
           it.showOnboardingPermissions = true
         }
       }
@@ -753,6 +801,7 @@ class MainActivity : ComponentActivity() {
     if (showOnboardingPermissions) {
       var wantContacts by remember { mutableStateOf(true) }
       var wantPhotos by remember { mutableStateOf(true) }
+      var wantCalendar by remember { mutableStateOf(true) }
 
       // Remembers that the offer was made whichever way it is answered, including a tap outside,
       // so nobody is asked twice.
@@ -767,6 +816,9 @@ class MainActivity : ComponentActivity() {
             buildList {
               if (onboardingOffersContacts && wantContacts) {
                 add(android.Manifest.permission.READ_CONTACTS)
+              }
+              if (onboardingOffersCalendar && wantCalendar) {
+                add(android.Manifest.permission.READ_CALENDAR)
               }
               if (onboardingOffersPhotos && wantPhotos) {
                 add(android.Manifest.permission.READ_MEDIA_IMAGES)
@@ -783,8 +835,8 @@ class MainActivity : ComponentActivity() {
         text = {
           Column {
             Text(
-              "SearchLauncher finds your apps and settings straight away. Two things it can only " +
-                "reach if you let it:"
+              "SearchLauncher finds your apps and settings straight away. A few things it can " +
+                "only reach if you let it:"
             )
             if (onboardingOffersContacts) {
               Spacer(modifier = Modifier.height(16.dp))
@@ -794,6 +846,19 @@ class MainActivity : ComponentActivity() {
                   Text("Contacts")
                   Text(
                     "Type a name to call, message or mail someone.",
+                    style = MaterialTheme.typography.bodySmall,
+                  )
+                }
+              }
+            }
+            if (onboardingOffersCalendar) {
+              Spacer(modifier = Modifier.height(8.dp))
+              Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                Checkbox(checked = wantCalendar, onCheckedChange = { wantCalendar = it })
+                Column {
+                  Text("Calendar")
+                  Text(
+                    "Find events coming up in the next week.",
                     style = MaterialTheme.typography.bodySmall,
                   )
                 }

--- a/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
@@ -24,6 +24,7 @@ object PreferencesKeys {
   val HISTORY_LIMIT = intPreferencesKey("history_limit")
   val MIN_ICON_SIZE = intPreferencesKey("min_icon_size")
   val AUTO_THEME_FROM_WALLPAPER = booleanPreferencesKey("auto_theme_from_wallpaper")
+  val THEMED_ICONS = booleanPreferencesKey("themed_icons")
   val SEARCH_SHORTCUTS_ENABLED = booleanPreferencesKey("search_shortcuts_enabled")
 
   /**

--- a/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
@@ -133,6 +133,14 @@ class ResultLauncher(
         } else {
           Intent(Intent.ACTION_VIEW, Uri.parse(deepLink))
         }
+      val uri = intent.data
+      if (uri?.scheme == "content") {
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        val mime = result.packageName.takeIf { it.contains('/') }
+        if (mime != null && intent.type == null) {
+          intent.setDataAndType(uri, mime)
+        }
+      }
       launchIntent(intent, query)
     } catch (e: Exception) {
       e.printStackTrace()

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -17,7 +17,14 @@ import androidx.compose.ui.platform.LocalContext
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.ui.browser.BrowserActivity
 
-class SearchActivity : ComponentActivity() {
+class SearchActivity : ComponentActivity(), KeyShortcutHost {
+  override var keyShortcutHandler: ((android.view.KeyEvent) -> Boolean)? = null
+
+  override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+    if (keyShortcutHandler?.invoke(event) == true) return true
+    return super.dispatchKeyEvent(event)
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -150,9 +150,11 @@ fun SearchScreen(
   riseWithKeyboard: Boolean = false,
 ) {
   var searchResults by remember { mutableStateOf<List<SearchResult>>(emptyList()) }
+  var keyboardSelectedIndex by remember { mutableIntStateOf(0) }
   var isLoading by remember { mutableStateOf(false) }
   var isFallbackMode by remember { mutableStateOf(false) }
   val context = LocalContext.current
+  val inPip = (context as? PipCapable)?.inPictureInPicture == true
   val app = context.applicationContext as com.searchlauncher.app.SearchLauncherApp
   val scope = rememberCoroutineScope()
   val focusRequester = remember { FocusRequester() }
@@ -279,6 +281,45 @@ fun SearchScreen(
   // Private browsing is still its own activity: it runs in a separate process on purpose, and that
   // is a real handover to another instance rather than an artificial one.
   var browserOpen by remember { mutableStateOf(false) }
+  val shortcutHost = context as? KeyShortcutHost
+  val searchShortcutHandler = rememberUpdatedState { event: android.view.KeyEvent ->
+    if (browserOpen) false
+    else
+      when {
+        KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_ESCAPE) -> {
+          if (query.isNotEmpty()) onQueryChange("") else onDismiss()
+          true
+        }
+        KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_L, ctrl = true) ||
+          KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_K, ctrl = true) ||
+          KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_F, ctrl = true) -> {
+          focusRequester.requestFocus()
+          true
+        }
+        searchResults.isNotEmpty() &&
+          KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_DPAD_UP) -> {
+          // reverseLayout: index 0 sits next to the search bar, higher indices are above it.
+          keyboardSelectedIndex = (keyboardSelectedIndex + 1).coerceAtMost(searchResults.lastIndex)
+          scope.launch { listState.scrollToItem(keyboardSelectedIndex) }
+          true
+        }
+        searchResults.isNotEmpty() &&
+          KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_DPAD_DOWN) -> {
+          keyboardSelectedIndex = (keyboardSelectedIndex - 1).coerceAtLeast(0)
+          scope.launch { listState.scrollToItem(keyboardSelectedIndex) }
+          true
+        }
+        else -> false
+      }
+  }
+  DisposableEffect(shortcutHost, browserOpen) {
+    if (browserOpen) {
+      onDispose {}
+    } else {
+      shortcutHost?.keyShortcutHandler = { searchShortcutHandler.value(it) }
+      onDispose { shortcutHost?.keyShortcutHandler = null }
+    }
+  }
   /**
    * Set for the length of the browser's exit. The offset says the browser is still on screen for
    * all of it, which is true but not the point: from the moment home is asked for it is home that
@@ -737,6 +778,7 @@ fun SearchScreen(
   }
 
   LaunchedEffect(searchResults) {
+    keyboardSelectedIndex = 0
     if (searchResults.isNotEmpty()) {
       listState.scrollToItem(0)
     }
@@ -1257,100 +1299,104 @@ fun SearchScreen(
       // launcher leaves as one screen rather than as a hole opening around a floating preview.
       val homeSwipeOffset = Modifier.graphicsLayer { translationX = browserTabSwipe.offsetPx }
 
-      Box(modifier = Modifier.fillMaxSize().then(homeSwipeOffset)) {
-        WallpaperBackground(
-          showBackgroundImage = showBackgroundImage,
-          bottomPadding = wallpaperBottomPadding,
-          folderImages = folderImages,
-          lastImageUriString = lastImageUriString,
-          savedUriResolved = savedUriResolved,
-          modifier = Modifier.fillMaxSize(),
-          onOpenAppDrawer = {
-            scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeAppDrawer) }
-            onOpenAppDrawer()
-          },
-          onLongPress = { offset ->
-            menuOffset = offset
-            showBackgroundMenu = true
-            scope.launch { onboardingManager.markStepComplete(OnboardingStep.LongPressBackground) }
-          },
-          onTap = {
-            onDismiss()
-            // Tapping background also swipes? No, just dismiss.
-            // But if we want to complete "Swipe Background", we need to detect the swipe in
-            // WallpaperBackground
-          },
-          onPageChanged = { uri ->
-            currentWallpaperUri = uri
-            scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeBackground) }
-          },
-          onSwipeDownLeft = {
-            scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeNotifications) }
-            com.searchlauncher.app.util.SystemUtils.expandNotifications(context)
-          },
-          onSwipeDownRight = {
-            scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeQuickSettings) }
-            com.searchlauncher.app.util.SystemUtils.expandQuickSettings(context)
-          },
-        )
-
-        TutorialOverlay(currentStep = currentOnboardingStep, bottomPadding = bottomPadding)
-
-        if (showDefaultLauncherDialog) {
-          AlertDialog(
-            onDismissRequest = {
-              app.setAskedDefaultLauncher()
-              showDefaultLauncherDialog = false
+      if (!inPip) {
+        Box(modifier = Modifier.fillMaxSize().then(homeSwipeOffset)) {
+          WallpaperBackground(
+            showBackgroundImage = showBackgroundImage,
+            bottomPadding = wallpaperBottomPadding,
+            folderImages = folderImages,
+            lastImageUriString = lastImageUriString,
+            savedUriResolved = savedUriResolved,
+            modifier = Modifier.fillMaxSize(),
+            onOpenAppDrawer = {
+              scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeAppDrawer) }
+              onOpenAppDrawer()
             },
-            title = { Text("Set as Default Launcher?") },
-            text = { Text("Would you like to use SearchLauncher as your home screen?") },
-            confirmButton = {
-              Button(
-                onClick = {
-                  app.setAskedDefaultLauncher()
-                  showDefaultLauncherDialog = false
-                  scope.launch {
-                    onboardingManager.markStepComplete(OnboardingStep.SetDefaultLauncher)
-                  }
-                  val intent = Intent(android.provider.Settings.ACTION_HOME_SETTINGS)
-                  context.startActivity(intent)
-                }
-              ) {
-                Text("Yes")
-              }
-            },
-            dismissButton = {
-              TextButton(
-                onClick = {
-                  app.setAskedDefaultLauncher()
-                  showDefaultLauncherDialog = false
-                }
-              ) {
-                Text("Not now")
-              }
-            },
-          )
-        } else if (showConsentDialog) {
-          ConsentDialog(
-            onChoicesSaved = { allowAutocompleteSuggestions, allowCrashReporting ->
-              app.setConsent(allowCrashReporting)
+            onLongPress = { offset ->
+              menuOffset = offset
+              showBackgroundMenu = true
               scope.launch {
-                context.dataStore.edit { preferences ->
-                  preferences[PreferencesKeys.SEARCH_SHORTCUTS_ENABLED] =
-                    allowAutocompleteSuggestions
-                }
+                onboardingManager.markStepComplete(OnboardingStep.LongPressBackground)
               }
-              showConsentDialog = false
             },
-            onViewPrivacyPolicy = { showPrivacyPolicy = true },
+            onTap = {
+              onDismiss()
+              // Tapping background also swipes? No, just dismiss.
+              // But if we want to complete "Swipe Background", we need to detect the swipe in
+              // WallpaperBackground
+            },
+            onPageChanged = { uri ->
+              currentWallpaperUri = uri
+              scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeBackground) }
+            },
+            onSwipeDownLeft = {
+              scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeNotifications) }
+              com.searchlauncher.app.util.SystemUtils.expandNotifications(context)
+            },
+            onSwipeDownRight = {
+              scope.launch { onboardingManager.markStepComplete(OnboardingStep.SwipeQuickSettings) }
+              com.searchlauncher.app.util.SystemUtils.expandQuickSettings(context)
+            },
           )
-        }
 
-        if (showPrivacyPolicy) {
-          PrivacyPolicyDialog(
-            onDismiss = { showPrivacyPolicy = false },
-            policyText = loadPrivacyPolicyText(context),
-          )
+          TutorialOverlay(currentStep = currentOnboardingStep, bottomPadding = bottomPadding)
+
+          if (showDefaultLauncherDialog) {
+            AlertDialog(
+              onDismissRequest = {
+                app.setAskedDefaultLauncher()
+                showDefaultLauncherDialog = false
+              },
+              title = { Text("Set as Default Launcher?") },
+              text = { Text("Would you like to use SearchLauncher as your home screen?") },
+              confirmButton = {
+                Button(
+                  onClick = {
+                    app.setAskedDefaultLauncher()
+                    showDefaultLauncherDialog = false
+                    scope.launch {
+                      onboardingManager.markStepComplete(OnboardingStep.SetDefaultLauncher)
+                    }
+                    val intent = Intent(android.provider.Settings.ACTION_HOME_SETTINGS)
+                    context.startActivity(intent)
+                  }
+                ) {
+                  Text("Yes")
+                }
+              },
+              dismissButton = {
+                TextButton(
+                  onClick = {
+                    app.setAskedDefaultLauncher()
+                    showDefaultLauncherDialog = false
+                  }
+                ) {
+                  Text("Not now")
+                }
+              },
+            )
+          } else if (showConsentDialog) {
+            ConsentDialog(
+              onChoicesSaved = { allowAutocompleteSuggestions, allowCrashReporting ->
+                app.setConsent(allowCrashReporting)
+                scope.launch {
+                  context.dataStore.edit { preferences ->
+                    preferences[PreferencesKeys.SEARCH_SHORTCUTS_ENABLED] =
+                      allowAutocompleteSuggestions
+                  }
+                }
+                showConsentDialog = false
+              },
+              onViewPrivacyPolicy = { showPrivacyPolicy = true },
+            )
+          }
+
+          if (showPrivacyPolicy) {
+            PrivacyPolicyDialog(
+              onDismiss = { showPrivacyPolicy = false },
+              policyText = loadPrivacyPolicyText(context),
+            )
+          }
         }
       }
 
@@ -1403,13 +1449,14 @@ fun SearchScreen(
                 // a screen to its left. Open is simply the offset being a full screen, so there is
                 // no separate case for it — and a drag can move the pair without either of them
                 // needing to know whether it counts as open yet.
-                translationX = browserTabSwipe.offsetPx - browserTabSwipe.viewportWidthPx
+                translationX =
+                  if (inPip) 0f else browserTabSwipe.offsetPx - browserTabSwipe.viewportWidthPx
               }
           ) {
             BrowserScreen(
               navigationRequest = browserNavigation,
               privateMode = false,
-              showLauncherChrome = true,
+              showLauncherChrome = !inPip,
               browserMenuRequest = 0L,
               onBrowserMenuShown = {},
               tabActivationRequest = browserTabActivation,
@@ -1443,6 +1490,8 @@ fun SearchScreen(
               // directions, and the real home screen travels under the finger rather than a
               // wallpaper standing in for it.
               leaving = browserLeaving,
+              inPictureInPicture = inPip,
+              shortcutsEnabled = browserOpen,
               onLauncherDrag = { delta ->
                 browserTabSwipe.offsetPx =
                   (browserTabSwipe.offsetPx + delta).coerceIn(
@@ -1623,569 +1672,590 @@ fun SearchScreen(
         }
       }
 
-      Column(
-        modifier =
-          Modifier.fillMaxSize()
-            .then(homeSwipeOffset)
-            .padding(bottom = bottomPadding) // Push content up by reserved space
-            .padding(top = 16.dp, bottom = 12.dp),
-        verticalArrangement = Arrangement.Bottom,
-      ) {
-        if (searchResults.isNotEmpty()) {
-          // When opened from the browser, the results panel takes the page color like the rest
-          // of the chrome. SearchResultItem reads onSurface/onSurfaceVariant from the theme, so
-          // override those locally for contrast on arbitrary page colors.
-          val resultsColor = chromeBarColor ?: MaterialTheme.colorScheme.surface
-          val resultsContentColor =
-            chromeBarColor?.let {
-              if (it.luminance() > 0.5f) Color(0xFF1C1B1F) else Color(0xFFEDE8EE)
-            } ?: MaterialTheme.colorScheme.onSurface
-          val resultsColorScheme =
-            if (chromeBarColor != null) {
-              MaterialTheme.colorScheme.copy(
-                surface = resultsColor,
-                surfaceVariant = resultsColor,
-                onSurface = resultsContentColor,
-                onSurfaceVariant = resultsContentColor.copy(alpha = 0.8f),
-              )
-            } else {
-              MaterialTheme.colorScheme
-            }
-          MaterialTheme(colorScheme = resultsColorScheme) {
-            Surface(
-              modifier =
-                Modifier.fillMaxWidth()
-                  .weight(1f, fill = false)
-                  .padding(horizontal = 16.dp)
-                  .clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                  ) {},
-              shape = RoundedCornerShape(16.dp),
-              color = resultsColor,
-              contentColor = resultsContentColor,
-              tonalElevation = if (chromeBarColor != null) 0.dp else 2.dp,
-              shadowElevation = if (chromeBarColor != null) 8.dp else 0.dp,
-            ) {
-              if (isLoading) {
-                Box(
-                  modifier = Modifier.fillMaxWidth().padding(32.dp),
-                  contentAlignment = Alignment.Center,
-                ) {
-                  CircularProgressIndicator()
-                }
+      if (!inPip) {
+        Column(
+          modifier =
+            Modifier.fillMaxSize()
+              .then(homeSwipeOffset)
+              .padding(bottom = bottomPadding) // Push content up by reserved space
+              .padding(top = 16.dp, bottom = 12.dp),
+          verticalArrangement = Arrangement.Bottom,
+        ) {
+          if (searchResults.isNotEmpty()) {
+            // When opened from the browser, the results panel takes the page color like the rest
+            // of the chrome. SearchResultItem reads onSurface/onSurfaceVariant from the theme, so
+            // override those locally for contrast on arbitrary page colors.
+            val resultsColor = chromeBarColor ?: MaterialTheme.colorScheme.surface
+            val resultsContentColor =
+              chromeBarColor?.let {
+                if (it.luminance() > 0.5f) Color(0xFF1C1B1F) else Color(0xFFEDE8EE)
+              } ?: MaterialTheme.colorScheme.onSurface
+            val resultsColorScheme =
+              if (chromeBarColor != null) {
+                MaterialTheme.colorScheme.copy(
+                  surface = resultsColor,
+                  surfaceVariant = resultsColor,
+                  onSurface = resultsContentColor,
+                  onSurfaceVariant = resultsContentColor.copy(alpha = 0.8f),
+                )
               } else {
-                LazyColumn(
-                  state = listState,
-                  reverseLayout = true,
-                  contentPadding = PaddingValues(vertical = 8.dp),
-                ) {
-                  itemsIndexed(
-                    searchResults,
-                    key = { index, item -> "$index/${item.stableListKey}" },
-                  ) { index, result ->
-                    SearchResultItem(
-                      result = result,
-                      isFavorite = app.favoritesRepository.isFavorite(result),
-                      actions = menuActionsFor(result, index),
-                      onClick = {
-                        if (result is SearchResult.SearchIntent) {
-                          // If the title implies a direct search (or we
-                          // are in fallback mode with query), perform
-                          // search
-                          // OR if the result title was modified to
-                          // include "Search ... on ..."
-                          // A better check: if query is not empty AND
-                          // it's not just the trigger itself.
-                          // The logic below handles both cases.
+                MaterialTheme.colorScheme
+              }
+            MaterialTheme(colorScheme = resultsColorScheme) {
+              Surface(
+                modifier =
+                  Modifier.fillMaxWidth()
+                    .contentMaxWidth()
+                    .weight(1f, fill = false)
+                    .padding(horizontal = 16.dp)
+                    .clickable(
+                      indication = null,
+                      interactionSource = remember { MutableInteractionSource() },
+                    ) {},
+                shape = RoundedCornerShape(16.dp),
+                color = resultsColor,
+                contentColor = resultsContentColor,
+                tonalElevation = if (chromeBarColor != null) 0.dp else 2.dp,
+                shadowElevation = if (chromeBarColor != null) 8.dp else 0.dp,
+              ) {
+                if (isLoading) {
+                  Box(
+                    modifier = Modifier.fillMaxWidth().padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                  ) {
+                    CircularProgressIndicator()
+                  }
+                } else {
+                  LazyColumn(
+                    state = listState,
+                    reverseLayout = true,
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                  ) {
+                    itemsIndexed(
+                      searchResults,
+                      key = { index, item -> "$index/${item.stableListKey}" },
+                    ) { index, result ->
+                      SearchResultItem(
+                        result = result,
+                        highlighted = index == keyboardSelectedIndex,
+                        isFavorite = app.favoritesRepository.isFavorite(result),
+                        actions = menuActionsFor(result, index),
+                        onClick = {
+                          if (result is SearchResult.SearchIntent) {
+                            // If the title implies a direct search (or we
+                            // are in fallback mode with query), perform
+                            // search
+                            // OR if the result title was modified to
+                            // include "Search ... on ..."
+                            // A better check: if query is not empty AND
+                            // it's not just the trigger itself.
+                            // The logic below handles both cases.
 
-                          // If it's a "Search X on Y" action (inferred
-                          // from query context)
-                          if (
-                            query.isNotEmpty() &&
-                              !result.trigger.equals(query.trim(), ignoreCase = true) &&
-                              !result.title.contains(query.trim(), ignoreCase = true)
-                          ) {
-                            // Perform Search
-                            val shortcut =
-                              app.searchShortcutRepository.items.value
-                                .filterIsInstance<com.searchlauncher.app.data.SearchShortcut>()
-                                .find { it.alias == result.trigger }
+                            // If it's a "Search X on Y" action (inferred
+                            // from query context)
+                            if (
+                              query.isNotEmpty() &&
+                                !result.trigger.equals(query.trim(), ignoreCase = true) &&
+                                !result.title.contains(query.trim(), ignoreCase = true)
+                            ) {
+                              // Perform Search
+                              val shortcut =
+                                app.searchShortcutRepository.items.value
+                                  .filterIsInstance<com.searchlauncher.app.data.SearchShortcut>()
+                                  .find { it.alias == result.trigger }
 
-                            if (shortcut != null) {
-                              launchShortcutSearch(
+                              if (shortcut != null) {
+                                launchShortcutSearch(
+                                  context = context,
+                                  searchRepository = searchRepository,
+                                  shortcut = shortcut,
+                                  result = result,
+                                  query = query,
+                                  privateWebResults = privateWebResults,
+                                  wasFirstResult = index == 0,
+                                  openInBrowser = { openInBrowser(it) },
+                                  onDismiss = onDismiss,
+                                )
+                              }
+                            } else {
+                              // Enter sub-search mode (append trigger)
+                              onQueryChange(result.trigger + " ")
+                            }
+                          } else {
+                            if (
+                              result is SearchResult.Content &&
+                                result.deepLink?.startsWith(
+                                  "intent:#Intent;action=com.searchlauncher.action.CREATE_SNIPPET"
+                                ) == true
+                            ) {
+                              snippetEditMode = false
+                              snippetInitialContent =
+                                Regex("S\\.content=([^;]*)")
+                                  .find(result.deepLink)
+                                  ?.groupValues
+                                  ?.get(1)
+                                  ?.let { Uri.decode(it) } ?: ""
+                              showSnippetDialog = true
+                            } else {
+                              launchResultPreferringPrivateBrowser(
                                 context = context,
-                                searchRepository = searchRepository,
-                                shortcut = shortcut,
                                 result = result,
                                 query = query,
+                                searchShortcuts = searchShortcuts,
                                 privateWebResults = privateWebResults,
+                                resultLauncher = resultLauncher,
                                 wasFirstResult = index == 0,
-                                openInBrowser = { openInBrowser(it) },
-                                onDismiss = onDismiss,
                               )
-                            }
-                          } else {
-                            // Enter sub-search mode (append trigger)
-                            onQueryChange(result.trigger + " ")
-                          }
-                        } else {
-                          if (
-                            result is SearchResult.Content &&
-                              result.deepLink?.startsWith(
-                                "intent:#Intent;action=com.searchlauncher.action.CREATE_SNIPPET"
-                              ) == true
-                          ) {
-                            snippetEditMode = false
-                            snippetInitialContent =
-                              Regex("S\\.content=([^;]*)")
-                                .find(result.deepLink)
-                                ?.groupValues
-                                ?.get(1)
-                                ?.let { Uri.decode(it) } ?: ""
-                            showSnippetDialog = true
-                          } else {
-                            launchResultPreferringPrivateBrowser(
-                              context = context,
-                              result = result,
-                              query = query,
-                              searchShortcuts = searchShortcuts,
-                              privateWebResults = privateWebResults,
-                              resultLauncher = resultLauncher,
-                              wasFirstResult = index == 0,
-                            )
-                            val keepSearchOpen =
-                              result is SearchResult.Content &&
-                                (result.deepLink ==
-                                  "intent:#Intent;action=com.searchlauncher.action.APPEND_SPACE;end" ||
-                                  result.deepLink ==
-                                    "intent:#Intent;action=com.searchlauncher.action.ADD_WIDGET;end")
-                            if (keepSearchOpen) {
-                              // Do nothing (keep search open)
-                            } else {
-                              onDismiss()
+                              val keepSearchOpen =
+                                result is SearchResult.Content &&
+                                  (result.deepLink ==
+                                    "intent:#Intent;action=com.searchlauncher.action.APPEND_SPACE;end" ||
+                                    result.deepLink ==
+                                      "intent:#Intent;action=com.searchlauncher.action.ADD_WIDGET;end")
+                              if (keepSearchOpen) {
+                                // Do nothing (keep search open)
+                              } else {
+                                onDismiss()
+                              }
                             }
                           }
-                        }
-                      },
-                    )
-                  }
-                }
-              }
-            }
-          }
-
-          Spacer(modifier = Modifier.height(4.dp))
-        }
-
-        // Measured as a block: the tabs overview stacks on top of the whole bottom section, so an
-        // open favorites row has to push the strip up with it rather than be drawn over.
-        if (favoritesRowVisible) {
-          Column(modifier = Modifier.onSizeChanged { favoritesRowHeightPx = it.height }) {
-            FavoritesRow(
-              favorites = favorites,
-              history = historyItems,
-              historyLimit = historyLimit,
-              minIconSizeSetting = minIconSizeSetting,
-              onLaunch = { result ->
-                if (result is SearchResult.SearchIntent) {
-                  searchRepository.reportUsageAsync(result.namespace, result.id)
-                  onQueryChange(result.trigger + " ")
-                } else {
-                  resultLauncher.launch(result, reportUsage = true)
-                  onDismiss()
-                }
-              },
-              onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result) },
-              onReorder = { newOrder ->
-                app.favoritesRepository.updateOrder(newOrder)
-                scope.launch { onboardingManager.markStepComplete(OnboardingStep.ReorderFavorites) }
-              },
-              onCapacityChanged = { limit -> searchRepository.updateObservedHistoryLimit(limit) },
-              // The same menu the results list offers, so long-pressing an app here and long-
-              // pressing it in the results are the same gesture with the same answer.
-              menuActions = { result -> menuActionsFor(result, -1) },
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-          }
-        }
-
-        SearchChromeBar(
-          isIndexing = isIndexing,
-          modifier =
-            Modifier.onSizeChanged { chromeBarHeightPx = it.height }
-              .browserTabSwipe(
-                state = browserTabSwipe,
-                enabled = browserTabSwipeEnabled,
-                tabsOverviewOpen = tabsOverviewOpen,
-                onOpenTabsOverview = ::openTabsOverview,
-                onCloseTabsOverview = { tabsOverviewOpen = false },
-                onCommitLastTab = ::retractKeyboardForTab,
-                // No activity to start any more: the browser is already composed at the end of the
-                // swipe, so committing it is just letting go of the offset.
-                onOpenLastTab = { browserOpen = true },
-                // Built while the finger is still still, so the drag itself has nothing left to do
-                // but move. Only ever with a tab to show — see the gesture, which checks.
-                onSidewaysDragStart = { browserWarm = true },
-                onSidewaysDragAbandoned = { browserWarm = false },
-              ),
-          color = chromeBarColor ?: MaterialTheme.colorScheme.surface,
-          contentColor =
-            chromeBarColor?.let {
-              if (it.luminance() > 0.5f) Color(0xFF1C1B1F) else Color(0xFFEDE8EE)
-            } ?: MaterialTheme.colorScheme.onSurface,
-          // As a browser overlay the bar floats over the page, which may be the exact same
-          // color — a shadow keeps it readable as its own layer.
-          shadowElevation = if (chromeBarColor != null) 8.dp else 0.dp,
-        ) {
-          val activeShortcut =
-            remember(query) {
-              var shortcut =
-                app.searchShortcutRepository.items.value.find {
-                  query.startsWith("${it.alias} ", ignoreCase = true)
-                }
-              if (shortcut == null) {
-                shortcut =
-                  com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
-                    query.startsWith("${it.alias} ", ignoreCase = true)
-                  }
-              }
-              shortcut
-            }
-
-          if (activeShortcut != null) {
-            Surface(
-              color = androidx.compose.ui.graphics.Color(activeShortcut.color ?: 0xFF808080),
-              shape = RoundedCornerShape(16.dp),
-              modifier = Modifier.padding(end = 8.dp),
-            ) {
-              Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-              ) {
-                val defaultShortcut =
-                  com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
-                    it.alias == activeShortcut.alias
-                  }
-                val label =
-                  (activeShortcut.shortLabel
-                      ?: defaultShortcut?.shortLabel
-                      ?: activeShortcut.description)
-                    .replace("Search ", "", ignoreCase = true)
-                    .replace("Ask ", "", ignoreCase = true)
-                    .trim()
-                Text(
-                  text = label,
-                  color = androidx.compose.ui.graphics.Color.White,
-                  fontSize = 14.sp,
-                  fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
-                )
-              }
-            }
-          }
-
-          val displayQuery =
-            if (activeShortcut != null) {
-              query.substring("${activeShortcut.alias} ".length)
-            } else {
-              query
-            }
-
-          var textFieldValue by remember {
-            mutableStateOf(
-              androidx.compose.ui.text.input.TextFieldValue(
-                text = displayQuery,
-                selection = androidx.compose.ui.text.TextRange(displayQuery.length),
-              )
-            )
-          }
-
-          // Update TextFieldValue when displayQuery changes externally (e.g. from "Add Widget")
-          LaunchedEffect(displayQuery) {
-            if (textFieldValue.text != displayQuery) {
-              textFieldValue =
-                textFieldValue.copy(
-                  text = displayQuery,
-                  selection = androidx.compose.ui.text.TextRange(displayQuery.length),
-                )
-            }
-          }
-
-          BasicTextField(
-            value = textFieldValue,
-            onValueChange = { newValue ->
-              textFieldValue = newValue
-              val newText = newValue.text
-              if (activeShortcut != null) {
-                onQueryChange("${activeShortcut.alias} $newText")
-              } else {
-                onQueryChange(newText)
-              }
-            },
-            modifier =
-              Modifier.weight(1f).focusRequester(focusRequester).onKeyEvent { event ->
-                if (
-                  event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
-                    displayQuery.isEmpty() &&
-                    activeShortcut != null
-                ) {
-                  onQueryChange("")
-                  true
-                } else {
-                  false
-                }
-              },
-            textStyle =
-              LocalTextStyle.current.copy(fontSize = 16.sp, color = LocalContentColor.current),
-            // Autocorrect off keeps the query literal: package names, commands and URL fragments
-            // are not dictionary words, and a silent rewrite is harder to notice than a typo.
-            keyboardOptions =
-              KeyboardOptions(imeAction = ImeAction.Go, autoCorrectEnabled = autocorrectEnabled),
-            keyboardActions =
-              KeyboardActions(
-                onGo = {
-                  val topResult = searchResults.firstOrNull()
-                  if (topResult != null) {
-                    if (topResult is SearchResult.SearchIntent) {
-                      if (isFallbackMode && query.isNotEmpty()) {
-                        // In fallback mode (e.g. random
-                        // text), 'Go' should perform the
-                        // search
-                        // using the top shortcut, instead
-                        // of just expanding the filter.
-                        val shortcut =
-                          app.searchShortcutRepository.items.value.find {
-                            it.alias == topResult.trigger
-                          }
-
-                        if (shortcut != null) {
-                          launchShortcutSearch(
-                            context = context,
-                            searchRepository = searchRepository,
-                            shortcut = shortcut,
-                            result = topResult,
-                            query = query,
-                            privateWebResults = privateWebResults,
-                            wasFirstResult = true,
-                            openInBrowser = { openInBrowser(it) },
-                            onDismiss = onDismiss,
-                          )
-                        } else {
-                          // Should not happen if data
-                          // integrity is good, but
-                          // fallback:
-                          onQueryChange(topResult.trigger + " ")
-                        }
-                      } else {
-                        // Normal mode: pressing enter on a
-                        // shortcut expands it (sub-search)
-                        onQueryChange(topResult.trigger + " ")
-                      }
-                    } else {
-                      launchResultPreferringPrivateBrowser(
-                        context = context,
-                        result = topResult,
-                        query = query,
-                        searchShortcuts = searchShortcuts,
-                        privateWebResults = privateWebResults,
-                        resultLauncher = resultLauncher,
-                        wasFirstResult = true,
+                        },
                       )
-                      onDismiss()
                     }
                   }
                 }
-              ),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-            interactionSource = searchFieldInteractionSource,
-            decorationBox = { innerTextField ->
-              Box(contentAlignment = Alignment.CenterStart) {
-                if (displayQuery.isEmpty() && activeShortcut == null) {
-                  if (isListening) {
-                    Text(
-                      text = "Listening...",
-                      color = MaterialTheme.colorScheme.primary,
-                      fontSize = 16.sp,
-                      maxLines = 1,
-                      overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                    )
+              }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+          }
+
+          // Measured as a block: the tabs overview stacks on top of the whole bottom section, so an
+          // open favorites row has to push the strip up with it rather than be drawn over.
+          if (favoritesRowVisible) {
+            Column(
+              modifier =
+                Modifier.contentMaxWidth().onSizeChanged { favoritesRowHeightPx = it.height }
+            ) {
+              FavoritesRow(
+                favorites = favorites,
+                history = historyItems,
+                historyLimit = historyLimit,
+                minIconSizeSetting = minIconSizeSetting,
+                onLaunch = { result ->
+                  if (result is SearchResult.SearchIntent) {
+                    searchRepository.reportUsageAsync(result.namespace, result.id)
+                    onQueryChange(result.trigger + " ")
                   } else {
-                    AnimatedContent(
-                      targetState = currentHint,
-                      transitionSpec = { fadeIn() togetherWith fadeOut() },
-                      label = "HintAnimation",
-                    ) { targetHint ->
+                    resultLauncher.launch(result, reportUsage = true)
+                    onDismiss()
+                  }
+                },
+                onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result) },
+                onReorder = { newOrder ->
+                  app.favoritesRepository.updateOrder(newOrder)
+                  scope.launch {
+                    onboardingManager.markStepComplete(OnboardingStep.ReorderFavorites)
+                  }
+                },
+                onCapacityChanged = { limit -> searchRepository.updateObservedHistoryLimit(limit) },
+                // The same menu the results list offers, so long-pressing an app here and long-
+                // pressing it in the results are the same gesture with the same answer.
+                menuActions = { result -> menuActionsFor(result, -1) },
+              )
+              Spacer(modifier = Modifier.height(2.dp))
+            }
+          }
+
+          SearchChromeBar(
+            isIndexing = isIndexing,
+            modifier =
+              Modifier.onSizeChanged { chromeBarHeightPx = it.height }
+                .browserTabSwipe(
+                  state = browserTabSwipe,
+                  enabled = browserTabSwipeEnabled,
+                  tabsOverviewOpen = tabsOverviewOpen,
+                  onOpenTabsOverview = ::openTabsOverview,
+                  onCloseTabsOverview = { tabsOverviewOpen = false },
+                  onCommitLastTab = ::retractKeyboardForTab,
+                  // No activity to start any more: the browser is already composed at the end of
+                  // the
+                  // swipe, so committing it is just letting go of the offset.
+                  onOpenLastTab = { browserOpen = true },
+                  // Built while the finger is still still, so the drag itself has nothing left to
+                  // do
+                  // but move. Only ever with a tab to show — see the gesture, which checks.
+                  onSidewaysDragStart = { browserWarm = true },
+                  onSidewaysDragAbandoned = { browserWarm = false },
+                ),
+            color = chromeBarColor ?: MaterialTheme.colorScheme.surface,
+            contentColor =
+              chromeBarColor?.let {
+                if (it.luminance() > 0.5f) Color(0xFF1C1B1F) else Color(0xFFEDE8EE)
+              } ?: MaterialTheme.colorScheme.onSurface,
+            // As a browser overlay the bar floats over the page, which may be the exact same
+            // color — a shadow keeps it readable as its own layer.
+            shadowElevation = if (chromeBarColor != null) 8.dp else 0.dp,
+          ) {
+            val activeShortcut =
+              remember(query) {
+                var shortcut =
+                  app.searchShortcutRepository.items.value.find {
+                    query.startsWith("${it.alias} ", ignoreCase = true)
+                  }
+                if (shortcut == null) {
+                  shortcut =
+                    com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
+                      query.startsWith("${it.alias} ", ignoreCase = true)
+                    }
+                }
+                shortcut
+              }
+
+            if (activeShortcut != null) {
+              Surface(
+                color = androidx.compose.ui.graphics.Color(activeShortcut.color ?: 0xFF808080),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier.padding(end = 8.dp),
+              ) {
+                Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                ) {
+                  val defaultShortcut =
+                    com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
+                      it.alias == activeShortcut.alias
+                    }
+                  val label =
+                    (activeShortcut.shortLabel
+                        ?: defaultShortcut?.shortLabel
+                        ?: activeShortcut.description)
+                      .replace("Search ", "", ignoreCase = true)
+                      .replace("Ask ", "", ignoreCase = true)
+                      .trim()
+                  Text(
+                    text = label,
+                    color = androidx.compose.ui.graphics.Color.White,
+                    fontSize = 14.sp,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+                  )
+                }
+              }
+            }
+
+            val displayQuery =
+              if (activeShortcut != null) {
+                query.substring("${activeShortcut.alias} ".length)
+              } else {
+                query
+              }
+
+            var textFieldValue by remember {
+              mutableStateOf(
+                androidx.compose.ui.text.input.TextFieldValue(
+                  text = displayQuery,
+                  selection = androidx.compose.ui.text.TextRange(displayQuery.length),
+                )
+              )
+            }
+
+            // Update TextFieldValue when displayQuery changes externally (e.g. from "Add Widget")
+            LaunchedEffect(displayQuery) {
+              if (textFieldValue.text != displayQuery) {
+                textFieldValue =
+                  textFieldValue.copy(
+                    text = displayQuery,
+                    selection = androidx.compose.ui.text.TextRange(displayQuery.length),
+                  )
+              }
+            }
+
+            BasicTextField(
+              value = textFieldValue,
+              onValueChange = { newValue ->
+                textFieldValue = newValue
+                val newText = newValue.text
+                if (activeShortcut != null) {
+                  onQueryChange("${activeShortcut.alias} $newText")
+                } else {
+                  onQueryChange(newText)
+                }
+              },
+              modifier =
+                Modifier.weight(1f).focusRequester(focusRequester).onKeyEvent { event ->
+                  if (
+                    event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
+                      displayQuery.isEmpty() &&
+                      activeShortcut != null
+                  ) {
+                    onQueryChange("")
+                    true
+                  } else {
+                    false
+                  }
+                },
+              textStyle =
+                LocalTextStyle.current.copy(fontSize = 16.sp, color = LocalContentColor.current),
+              // Autocorrect off keeps the query literal: package names, commands and URL fragments
+              // are not dictionary words, and a silent rewrite is harder to notice than a typo.
+              keyboardOptions =
+                KeyboardOptions(imeAction = ImeAction.Go, autoCorrectEnabled = autocorrectEnabled),
+              keyboardActions =
+                KeyboardActions(
+                  onGo = {
+                    val topResult =
+                      searchResults.getOrNull(keyboardSelectedIndex) ?: searchResults.firstOrNull()
+                    if (topResult != null) {
+                      if (topResult is SearchResult.SearchIntent) {
+                        if (isFallbackMode && query.isNotEmpty()) {
+                          // In fallback mode (e.g. random
+                          // text), 'Go' should perform the
+                          // search
+                          // using the top shortcut, instead
+                          // of just expanding the filter.
+                          val shortcut =
+                            app.searchShortcutRepository.items.value.find {
+                              it.alias == topResult.trigger
+                            }
+
+                          if (shortcut != null) {
+                            launchShortcutSearch(
+                              context = context,
+                              searchRepository = searchRepository,
+                              shortcut = shortcut,
+                              result = topResult,
+                              query = query,
+                              privateWebResults = privateWebResults,
+                              wasFirstResult = keyboardSelectedIndex == 0,
+                              openInBrowser = { openInBrowser(it) },
+                              onDismiss = onDismiss,
+                            )
+                          } else {
+                            // Should not happen if data
+                            // integrity is good, but
+                            // fallback:
+                            onQueryChange(topResult.trigger + " ")
+                          }
+                        } else {
+                          // Normal mode: pressing enter on a
+                          // shortcut expands it (sub-search)
+                          onQueryChange(topResult.trigger + " ")
+                        }
+                      } else {
+                        launchResultPreferringPrivateBrowser(
+                          context = context,
+                          result = topResult,
+                          query = query,
+                          searchShortcuts = searchShortcuts,
+                          privateWebResults = privateWebResults,
+                          resultLauncher = resultLauncher,
+                          wasFirstResult = keyboardSelectedIndex == 0,
+                        )
+                        onDismiss()
+                      }
+                    }
+                  }
+                ),
+              cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+              interactionSource = searchFieldInteractionSource,
+              decorationBox = { innerTextField ->
+                Box(contentAlignment = Alignment.CenterStart) {
+                  if (displayQuery.isEmpty() && activeShortcut == null) {
+                    if (isListening) {
                       Text(
-                        text = targetHint,
-                        color = LocalContentColor.current.copy(alpha = 0.72f),
+                        text = "Listening...",
+                        color = MaterialTheme.colorScheme.primary,
                         fontSize = 16.sp,
                         maxLines = 1,
                         overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                       )
+                    } else {
+                      AnimatedContent(
+                        targetState = currentHint,
+                        transitionSpec = { fadeIn() togetherWith fadeOut() },
+                        label = "HintAnimation",
+                      ) { targetHint ->
+                        Text(
+                          text = targetHint,
+                          color = LocalContentColor.current.copy(alpha = 0.72f),
+                          fontSize = 16.sp,
+                          maxLines = 1,
+                          overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        )
+                      }
                     }
                   }
+                  innerTextField()
                 }
-                innerTextField()
-              }
-            },
-          )
+              },
+            )
 
-          if (query.isNotEmpty()) {
-            // Resolved once and shared by the badge, the tap and the menu, so what the button
-            // shows, what it does and what the menu ticks cannot drift apart.
-            val engines =
-              remember(searchShortcuts) {
-                (com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts + searchShortcuts)
-                  .filter { it.urlTemplate.startsWith("http") }
-                  .distinctBy { it.id }
-              }
-            val engine =
-              remember(engines, defaultSearchEngineId) {
-                engines.firstOrNull { it.id == defaultSearchEngineId }
-                  ?: engines.firstOrNull { it.id == "google" }
-                  ?: engines.first()
-              }
-            var engineMenuOpen by remember { mutableStateOf(false) }
+            if (query.isNotEmpty()) {
+              // Resolved once and shared by the badge, the tap and the menu, so what the button
+              // shows, what it does and what the menu ticks cannot drift apart.
+              val engines =
+                remember(searchShortcuts) {
+                  (com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts + searchShortcuts)
+                    .filter { it.urlTemplate.startsWith("http") }
+                    .distinctBy { it.id }
+                }
+              val engine =
+                remember(engines, defaultSearchEngineId) {
+                  engines.firstOrNull { it.id == defaultSearchEngineId }
+                    ?: engines.firstOrNull { it.id == "google" }
+                    ?: engines.first()
+                }
+              var engineMenuOpen by remember { mutableStateOf(false) }
 
-            Box {
-              // Drawn here rather than scaled down from the generator's 40dp bitmap, which at this
-              // size rounded off into a circle. Same recipe as the badges in the result list — the
-              // engine's colour, its alias on it — at a fifth of the side, which is the corner they
-              // are drawn with, so the two read as the same shape.
-              Surface(
-                color = Color(engine.color ?: 0xFF808080),
-                shape = RoundedCornerShape(percent = 20),
-                modifier =
-                  Modifier.size(24.dp)
-                    .combinedClickable(
-                      onClick = {
-                        openBrowser(context, engine.urlForQuery(query), privateWebResults) {
-                          openInBrowser(it)
-                        }
-                        onDismiss()
-                      },
-                      onLongClick = { engineMenuOpen = true },
-                    ),
-              ) {
-                Box(contentAlignment = Alignment.Center) {
+              Box {
+                // Drawn here rather than scaled down from the generator's 40dp bitmap, which at
+                // this
+                // size rounded off into a circle. Same recipe as the badges in the result list —
+                // the
+                // engine's colour, its alias on it — at a fifth of the side, which is the corner
+                // they
+                // are drawn with, so the two read as the same shape.
+                Surface(
+                  color = Color(engine.color ?: 0xFF808080),
+                  shape = RoundedCornerShape(percent = 20),
+                  modifier =
+                    Modifier.size(24.dp)
+                      .combinedClickable(
+                        onClick = {
+                          openBrowser(context, engine.urlForQuery(query), privateWebResults) {
+                            openInBrowser(it)
+                          }
+                          onDismiss()
+                        },
+                        onLongClick = { engineMenuOpen = true },
+                      ),
+                ) {
+                  Box(contentAlignment = Alignment.Center) {
+                    Text(
+                      text = engine.alias.uppercase(),
+                      color = Color.White,
+                      fontSize = 11.sp,
+                      fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                      maxLines = 1,
+                    )
+                  }
+                }
+
+                // The same list the settings page offers, written to the same preference, so
+                // changing
+                // it here is changing it there.
+                DropdownMenu(
+                  expanded = engineMenuOpen,
+                  onDismissRequest = { engineMenuOpen = false },
+                ) {
                   Text(
-                    text = engine.alias.uppercase(),
-                    color = Color.White,
-                    fontSize = 11.sp,
-                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                    maxLines = 1,
+                    text = "Set default search engine",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                   )
+                  engines.forEach { candidate ->
+                    DropdownMenuItem(
+                      text = { Text(candidate.shortLabel ?: candidate.description) },
+                      onClick = {
+                        engineMenuOpen = false
+                        scope.launch {
+                          context.dataStore.edit { preferences ->
+                            preferences[PreferencesKeys.DEFAULT_SEARCH_ENGINE] = candidate.id
+                          }
+                        }
+                      },
+                      leadingIcon = {
+                        Surface(
+                          color = Color(candidate.color ?: 0xFF808080),
+                          shape = RoundedCornerShape(percent = 20),
+                          modifier = Modifier.size(24.dp),
+                        ) {
+                          Box(contentAlignment = Alignment.Center) {
+                            Text(
+                              text = candidate.alias.uppercase(),
+                              color = Color.White,
+                              fontSize = 11.sp,
+                              fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                              maxLines = 1,
+                            )
+                          }
+                        }
+                      },
+                      trailingIcon = {
+                        if (candidate.id == engine.id) {
+                          Icon(Icons.Default.Check, contentDescription = "Current default")
+                        }
+                      },
+                    )
+                  }
                 }
               }
-
-              // The same list the settings page offers, written to the same preference, so changing
-              // it here is changing it there.
-              DropdownMenu(
-                expanded = engineMenuOpen,
-                onDismissRequest = { engineMenuOpen = false },
-              ) {
-                Text(
-                  text = "Set default search engine",
-                  style = MaterialTheme.typography.labelMedium,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant,
-                  modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                )
-                engines.forEach { candidate ->
-                  DropdownMenuItem(
-                    text = { Text(candidate.shortLabel ?: candidate.description) },
-                    onClick = {
-                      engineMenuOpen = false
-                      scope.launch {
-                        context.dataStore.edit { preferences ->
-                          preferences[PreferencesKeys.DEFAULT_SEARCH_ENGINE] = candidate.id
-                        }
-                      }
-                    },
-                    leadingIcon = {
-                      Surface(
-                        color = Color(candidate.color ?: 0xFF808080),
-                        shape = RoundedCornerShape(percent = 20),
-                        modifier = Modifier.size(24.dp),
-                      ) {
-                        Box(contentAlignment = Alignment.Center) {
-                          Text(
-                            text = candidate.alias.uppercase(),
-                            color = Color.White,
-                            fontSize = 11.sp,
-                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                            maxLines = 1,
-                          )
-                        }
-                      }
-                    },
-                    trailingIcon = {
-                      if (candidate.id == engine.id) {
-                        Icon(Icons.Default.Check, contentDescription = "Current default")
-                      }
-                    },
-                  )
-                }
-              }
-            }
-            IconButton(
-              onClick = { onQueryChange("") },
-              modifier = Modifier.size(32.dp).padding(4.dp),
-            ) {
-              Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "Clear",
-                tint = LocalContentColor.current,
-              )
-            }
-          } else {
-            // First, because it is the one that comes and goes: only once the browser has tabs to
-            // show. Unlike in the browser, where there is always at least one, a launcher that has
-            // never opened a page has nothing to count. Sitting between the other two, it shoved
-            // the mic sideways the moment a tab appeared, so the two buttons that are always there
-            // never settled anywhere. Leading the row, it grows away from them instead.
-            if (browserTabSwipeEnabled && openTabCount > 0) {
-              BrowserTabsButton(
-                tabCount = openTabCount,
-                onClick = { if (tabsOverviewOpen) tabsOverviewOpen = false else openTabsOverview() },
-              )
-            }
-
-            IconButton(
-              onClick = startOrStopVoiceSearch,
-              modifier = Modifier.size(32.dp).padding(4.dp),
-            ) {
-              Icon(
-                imageVector = Icons.Default.Mic,
-                contentDescription = "Voice Search",
-                tint =
-                  if (isListening) MaterialTheme.colorScheme.primary else LocalContentColor.current,
-              )
-            }
-
-            if (onOpenBrowserContext != null) {
               IconButton(
-                onClick = onOpenBrowserContext,
+                onClick = { onQueryChange("") },
                 modifier = Modifier.size(32.dp).padding(4.dp),
               ) {
                 Icon(
-                  imageVector = Icons.Default.MoreVert,
-                  contentDescription = "Browser menu",
+                  imageVector = Icons.Default.Close,
+                  contentDescription = "Clear",
                   tint = LocalContentColor.current,
                 )
               }
             } else {
+              // First, because it is the one that comes and goes: only once the browser has tabs to
+              // show. Unlike in the browser, where there is always at least one, a launcher that
+              // has
+              // never opened a page has nothing to count. Sitting between the other two, it shoved
+              // the mic sideways the moment a tab appeared, so the two buttons that are always
+              // there
+              // never settled anywhere. Leading the row, it grows away from them instead.
+              if (browserTabSwipeEnabled && openTabCount > 0) {
+                BrowserTabsButton(
+                  tabCount = openTabCount,
+                  onClick = {
+                    if (tabsOverviewOpen) tabsOverviewOpen = false else openTabsOverview()
+                  },
+                )
+              }
+
               IconButton(
-                onClick = {
-                  scope.launch { onboardingManager.markStepComplete(OnboardingStep.OpenSettings) }
-                  onOpenSettings()
-                },
+                onClick = startOrStopVoiceSearch,
                 modifier = Modifier.size(32.dp).padding(4.dp),
               ) {
                 Icon(
-                  imageVector = Icons.Default.Settings,
-                  contentDescription = "Settings",
-                  tint = LocalContentColor.current,
+                  imageVector = Icons.Default.Mic,
+                  contentDescription = "Voice Search",
+                  tint =
+                    if (isListening) MaterialTheme.colorScheme.primary
+                    else LocalContentColor.current,
                 )
+              }
+
+              if (onOpenBrowserContext != null) {
+                IconButton(
+                  onClick = onOpenBrowserContext,
+                  modifier = Modifier.size(32.dp).padding(4.dp),
+                ) {
+                  Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = "Browser menu",
+                    tint = LocalContentColor.current,
+                  )
+                }
+              } else {
+                IconButton(
+                  onClick = {
+                    scope.launch { onboardingManager.markStepComplete(OnboardingStep.OpenSettings) }
+                    onOpenSettings()
+                  },
+                  modifier = Modifier.size(32.dp).padding(4.dp),
+                ) {
+                  Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = "Settings",
+                    tint = LocalContentColor.current,
+                  )
+                }
               }
             }
           }

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -129,7 +129,8 @@ fun SettingsScreen(
 
   LazyColumn(
     state = listState,
-    modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 16.dp),
+    modifier =
+      Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 16.dp).contentMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(16.dp),
     contentPadding = PaddingValues(bottom = 32.dp),
   ) {
@@ -374,6 +375,25 @@ fun SettingsScreen(
             granted =
               rememberPermissionState {
                   ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS) ==
+                    PackageManager.PERMISSION_GRANTED
+                }
+                .value,
+            onGrant = {
+              val intent =
+                Intent(
+                  Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                  Uri.parse("package:${context.packageName}"),
+                )
+              context.startActivity(intent)
+            },
+          )
+
+          PermissionStatus(
+            title = "Calendar",
+            description = "Search events in the next week.",
+            granted =
+              rememberPermissionState {
+                  ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) ==
                     PackageManager.PERMISSION_GRANTED
                 }
                 .value,

--- a/app/src/main/java/com/searchlauncher/app/ui/ThemeSettingsCard.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ThemeSettingsCard.kt
@@ -123,13 +123,51 @@ fun ThemeSettingsCard() {
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
       ) {
-        Text(text = "Auto from wallpaper", style = MaterialTheme.typography.bodyMedium)
+        Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+          Text(text = "Auto from wallpaper", style = MaterialTheme.typography.bodyMedium)
+          Text(
+            text = "Tint the UI from the wallpaper currently behind the search bar.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
         Switch(
           checked = autoThemeFromWallpaper,
           onCheckedChange = { checked ->
             scope.launch {
               context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.AUTO_THEME_FROM_WALLPAPER] = checked
+              }
+            }
+          },
+        )
+      }
+
+      HorizontalDivider()
+
+      val themedIcons by
+        remember { context.dataStore.data.map { it[PreferencesKeys.THEMED_ICONS] ?: false } }
+          .collectAsState(initial = false)
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+          Text(text = "Themed icons", style = MaterialTheme.typography.bodyMedium)
+          Text(
+            text =
+              "Tint other apps' monochrome icons to match the theme, and let Android theme SearchLauncher's own icon the same way. Apps without a monochrome layer stay as they are.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        Switch(
+          checked = themedIcons,
+          onCheckedChange = { checked ->
+            scope.launch {
+              context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.THEMED_ICONS] = checked
               }
             }
           },

--- a/app/src/main/java/com/searchlauncher/app/ui/ThemedIcons.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ThemedIcons.kt
@@ -1,0 +1,47 @@
+package com.searchlauncher.app.ui
+
+import android.graphics.drawable.AdaptiveIconDrawable
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.flow.map
+
+/**
+ * Material You-style themed icons: the app's monochrome layer, tinted, on a theme-color plate.
+ *
+ * Apps that do not ship a monochrome layer are left alone. Pre-Android 13 has no monochrome API, so
+ * theming is a no-op there.
+ */
+object ThemedIcons {
+  fun apply(drawable: Drawable?, backgroundArgb: Int, foregroundArgb: Int): Drawable? {
+    if (drawable == null) return null
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return drawable
+    val adaptive = drawable as? AdaptiveIconDrawable ?: return drawable
+    val mono = adaptive.monochrome ?: return drawable
+    val foreground = (mono.constantState?.newDrawable() ?: mono).mutate()
+    foreground.setTint(foregroundArgb)
+    return AdaptiveIconDrawable(ColorDrawable(backgroundArgb), foreground)
+  }
+}
+
+@Composable
+fun rememberThemedIconBitmap(drawable: Drawable?): ImageBitmap? {
+  val context = LocalContext.current
+  val themed by
+    remember { context.dataStore.data.map { it[PreferencesKeys.THEMED_ICONS] ?: false } }
+      .collectAsState(initial = false)
+  val background = MaterialTheme.colorScheme.primary.toArgb()
+  val foreground = MaterialTheme.colorScheme.onPrimary.toArgb()
+  return remember(drawable, themed, background, foreground) {
+    val toDraw = if (themed) ThemedIcons.apply(drawable, background, foreground) else drawable
+    toDraw?.toImageBitmap()
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/WindowWidth.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/WindowWidth.kt
@@ -1,0 +1,32 @@
+package com.searchlauncher.app.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+
+/** Smallest width at which Android treats the device as a tablet / unfolded inner display. */
+const val TABLET_SMALLEST_WIDTH_DP = 600
+
+@Composable
+fun isTabletLayout(configuration: Configuration = LocalConfiguration.current): Boolean =
+  configuration.smallestScreenWidthDp >= TABLET_SMALLEST_WIDTH_DP
+
+/**
+ * On phones this is a no-op. On tablets the search chrome, results and settings sit at a readable
+ * column width in the middle rather than stretching edge to edge.
+ *
+ * Other tablet-sized layouts worth considering later, once this column is not enough: a two-pane
+ * settings screen, an app-list grid instead of a single column, and a split that keeps search
+ * beside the hosted browser instead of covering it.
+ */
+@Composable
+fun Modifier.contentMaxWidth(): Modifier {
+  if (!isTabletLayout()) return this
+  return fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally).widthIn(max = 720.dp)
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -2,23 +2,30 @@ package com.searchlauncher.app.ui.browser
 
 import android.annotation.SuppressLint
 import android.app.DownloadManager
+import android.app.PictureInPictureParams
 import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.util.Rational
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.webkit.CookieManager
 import android.webkit.GeolocationPermissions
 import android.webkit.PermissionRequest
 import android.webkit.URLUtil
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -107,8 +114,11 @@ import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.favoriteKey
+import com.searchlauncher.app.ui.KeyShortcutHost
+import com.searchlauncher.app.ui.KeyShortcuts
 import com.searchlauncher.app.ui.MainActivity
 import com.searchlauncher.app.ui.MinIconSize
+import com.searchlauncher.app.ui.PipCapable
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.ResultLauncher
 import com.searchlauncher.app.ui.SearchActivity
@@ -127,7 +137,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-open class BrowserActivity : ComponentActivity() {
+open class BrowserActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
   private var navigationRequest by mutableStateOf<NavigationRequest?>(null)
   private var searchOverlayVisible by mutableStateOf(false)
   private var browserMenuRequest by mutableLongStateOf(0L)
@@ -135,9 +145,18 @@ open class BrowserActivity : ComponentActivity() {
   /** Set between launching the search overlay and it taking window focus. */
   private var pendingSearchLaunch = false
   protected open val isPrivateMode: Boolean = false
+  override var keyShortcutHandler: ((android.view.KeyEvent) -> Boolean)? = null
+  override var pipVideoView: View? = null
+  override var inPictureInPicture by mutableStateOf(false)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    if (isPrivateMode) {
+      window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        setRecentsScreenshotEnabled(false)
+      }
+    }
     navigationRequest = intent.toNavigationRequest(0)
     // Applied before the first composition so the browser is built around the right tab instead
     // of building a WebView for the previous one and switching a frame later.
@@ -170,12 +189,13 @@ open class BrowserActivity : ComponentActivity() {
         BrowserScreen(
           navigationRequest = navigationRequest,
           privateMode = isPrivateMode,
-          showLauncherChrome = !searchOverlayVisible,
+          showLauncherChrome = !searchOverlayVisible && !inPictureInPicture,
           browserMenuRequest = browserMenuRequest,
           onBrowserMenuShown = { browserMenuRequest = 0L },
           tabActivationRequest = tabActivationRequest,
           onOpenSearch = { voice, color, query -> openSearch(voice, color, query) },
           onClose = ::finish,
+          inPictureInPicture = inPictureInPicture,
         )
       }
     }
@@ -214,6 +234,38 @@ open class BrowserActivity : ComponentActivity() {
   override fun onDestroy() {
     unregisterReceiver(browserActionReceiver)
     super.onDestroy()
+  }
+
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    if (keyShortcutHandler?.invoke(event) == true) return true
+    return super.dispatchKeyEvent(event)
+  }
+
+  override fun onUserLeaveHint() {
+    super.onUserLeaveHint()
+    enterPipIfEligible()
+  }
+
+  override fun onPictureInPictureModeChanged(
+    isInPictureInPictureMode: Boolean,
+    newConfig: Configuration,
+  ) {
+    super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+    inPictureInPicture = isInPictureInPictureMode
+  }
+
+  override fun enterPipIfEligible(): Boolean {
+    val view = pipVideoView ?: return false
+    if (isPrivateMode || isInPictureInPictureMode) return false
+    val width = view.width.coerceAtLeast(16)
+    val height = view.height.coerceAtLeast(9)
+    val params = PictureInPictureParams.Builder().setAspectRatio(Rational(width, height)).build()
+    return try {
+      enterPictureInPictureMode(params)
+    } catch (e: Exception) {
+      android.util.Log.w("BrowserActivity", "PiP failed", e)
+      false
+    }
   }
 
   @Composable
@@ -384,9 +436,19 @@ internal fun BrowserScreen(
   onLauncherDrag: ((Float) -> Unit)? = null,
   /** The finger left during such a drag, travelling at this many pixels a second. */
   onLauncherDragEnd: ((Float) -> Unit)? = null,
+  inPictureInPicture: Boolean = false,
+  shortcutsEnabled: Boolean = true,
 ) {
   val context = LocalContext.current
   val app = context.applicationContext as SearchLauncherApp
+  val fileChooser = remember { BrowserFileChooser() }
+  val fileChooserLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+      fileChooser.deliver(result.resultCode, result.data)
+    }
+  androidx.compose.runtime.SideEffect {
+    fileChooser.launch = { intent -> fileChooserLauncher.launch(intent) }
+  }
   // Read the shared favorites flow so the browser strip matches search — but only when there is
   // one to read. The private browser is a separate process with no repositories at all, so these
   // are absent there rather than merely read-only, and the strip falls back to empty.
@@ -664,6 +726,8 @@ internal fun BrowserScreen(
   var fullscreenVideoCallback by remember {
     mutableStateOf<WebChromeClient.CustomViewCallback?>(null)
   }
+  val pipHost = context as? PipCapable
+  LaunchedEffect(fullscreenVideoView) { pipHost?.pipVideoView = fullscreenVideoView }
   var restoringSnapshot by remember { mutableStateOf(activeTab.snapshot) }
   var tabDragOffsetPx by remember { mutableFloatStateOf(0f) }
   // Set while a tapped card in the overview is growing into the page, so the bars can travel with
@@ -962,6 +1026,7 @@ internal fun BrowserScreen(
   // The overview lives around the chrome bar, so it cannot outlast it: opening search from the
   // bar takes the bar away, which would strand the tab strip with no header.
   LaunchedEffect(showLauncherChrome) { if (!showLauncherChrome) tabsOverviewOpen = false }
+  LaunchedEffect(inPictureInPicture) { if (inPictureInPicture) showFindInPage = false }
 
   // Leaving the browser (home button, the search overlay, a swipe back to the launcher) is exactly
   // when the preview has to be current: it is what the launcher shows to swipe back in with.
@@ -1060,6 +1125,57 @@ internal fun BrowserScreen(
       if (view?.canGoBack() == true) view.goBack()
       else if (tabs.items.size > 1) closeActiveTab() else onClose()
     }
+  }
+
+  val shortcutHost = context as? KeyShortcutHost
+  val browserShortcutHandler = rememberUpdatedState { event: android.view.KeyEvent ->
+    when {
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_T, ctrl = true) -> {
+        createTab()
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_W, ctrl = true) -> {
+        closeActiveTab()
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_R, ctrl = true) -> {
+        webView?.reload()
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_F, ctrl = true) -> {
+        showFindInPage = true
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_L, ctrl = true) ||
+        KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_K, ctrl = true) -> {
+        onOpenSearch(false, animatedPageBackground.toArgb(), webView?.url ?: activeTab.url)
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_TAB, ctrl = true, shift = true) -> {
+        animateToAdjacentTab(-1)
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_TAB, ctrl = true) -> {
+        animateToAdjacentTab(1)
+        true
+      }
+      KeyShortcuts.matches(event, android.view.KeyEvent.KEYCODE_ESCAPE) -> {
+        if (tabsOverviewOpen) tabsOverviewOpen = false
+        else if (fullscreenVideoView != null) exitFullscreenVideo()
+        else if (showFindInPage) {
+          webView?.clearMatches()
+          showFindInPage = false
+        } else if (webView?.canGoBack() == true) webView?.goBack()
+        else if (tabs.items.size > 1) closeActiveTab() else onClose()
+        true
+      }
+      else -> false
+    }
+  }
+  DisposableEffect(shortcutHost, shortcutsEnabled) {
+    if (!shortcutsEnabled) return@DisposableEffect onDispose {}
+    shortcutHost?.keyShortcutHandler = { browserShortcutHandler.value(it) }
+    onDispose { shortcutHost?.keyShortcutHandler = null }
   }
 
   val chromeBarColor = animatedPageBackground
@@ -1421,6 +1537,12 @@ internal fun BrowserScreen(
                     fullscreenVideoView = null
                     fullscreenVideoCallback = null
                   }
+
+                  override fun onShowFileChooser(
+                    webView: WebView?,
+                    filePathCallback: ValueCallback<Array<Uri>>?,
+                    fileChooserParams: FileChooserParams?,
+                  ): Boolean = fileChooser.start(filePathCallback, fileChooserParams)
 
                   // searchRepository is null in private mode, so incognito browsing never writes
                   // favicons to disk.
@@ -2530,3 +2652,43 @@ private const val CLEAR_SITE_STORAGE_SCRIPT =
     } catch (_) {}
   })()
   """
+
+internal class BrowserFileChooser {
+  var callback: ValueCallback<Array<Uri>>? = null
+  var launch: ((Intent) -> Unit)? = null
+
+  fun start(
+    filePathCallback: ValueCallback<Array<Uri>>?,
+    fileChooserParams: WebChromeClient.FileChooserParams?,
+  ): Boolean {
+    callback?.onReceiveValue(null)
+    callback = filePathCallback
+    val intent =
+      try {
+        fileChooserParams?.createIntent()
+      } catch (_: Exception) {
+        null
+      }
+    val launcher = launch
+    if (filePathCallback == null || intent == null || launcher == null) {
+      callback?.onReceiveValue(null)
+      callback = null
+      return false
+    }
+    return try {
+      launcher(intent)
+      true
+    } catch (_: ActivityNotFoundException) {
+      callback?.onReceiveValue(null)
+      callback = null
+      false
+    }
+  }
+
+  fun deliver(resultCode: Int, data: Intent?) {
+    val pending = callback ?: return
+    val uris = WebChromeClient.FileChooserParams.parseResult(resultCode, data)
+    pending.onReceiveValue(uris)
+    callback = null
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -15,8 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
@@ -24,9 +26,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.favoriteKey
+import com.searchlauncher.app.ui.PreferencesKeys
+import com.searchlauncher.app.ui.ThemedIcons
+import com.searchlauncher.app.ui.dataStore
 import com.searchlauncher.app.ui.toImageBitmap
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -120,9 +126,20 @@ fun FavoritesRow(
         }
     }
 
-    // Caching icons to prevent flickering
+    val context = LocalContext.current
+    val themedIcons by
+      remember { context.dataStore.data.map { it[PreferencesKeys.THEMED_ICONS] ?: false } }
+        .collectAsState(initial = false)
+    val themeBg = MaterialTheme.colorScheme.primary.toArgb()
+    val themeFg = MaterialTheme.colorScheme.onPrimary.toArgb()
     val iconBitmaps =
-      remember(allItems) { allItems.associate { it.favoriteKey to it.icon?.toImageBitmap() } }
+      remember(allItems, themedIcons, themeBg, themeFg) {
+        allItems.associate { result ->
+          val drawable =
+            if (themedIcons) ThemedIcons.apply(result.icon, themeBg, themeFg) else result.icon
+          result.favoriteKey to drawable?.toImageBitmap()
+        }
+      }
 
     // Calculate layout metrics
     // We reserve space for the divider gap if needed

--- a/app/src/main/java/com/searchlauncher/app/ui/components/SearchChrome.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/SearchChrome.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.searchlauncher.app.ui.contentMaxWidth
 
 @Composable
 fun SearchChromeBar(
@@ -34,7 +35,7 @@ fun SearchChromeBar(
   content: @Composable RowScope.() -> Unit,
 ) {
   Surface(
-    modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp),
+    modifier = modifier.fillMaxWidth().contentMaxWidth().padding(horizontal = 16.dp),
     shape = RoundedCornerShape(16.dp),
     color = color,
     contentColor = contentColor,

--- a/app/src/main/java/com/searchlauncher/app/ui/components/SearchResultItem.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/SearchResultItem.kt
@@ -28,6 +28,7 @@ import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.ContactActionGlyph
 import com.searchlauncher.app.data.ContactChatAction
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.ui.rememberThemedIconBitmap
 import com.searchlauncher.app.ui.toImageBitmap
 import com.searchlauncher.app.util.traceSection
 
@@ -35,6 +36,7 @@ import com.searchlauncher.app.util.traceSection
 @Composable
 fun SearchResultItem(
   result: SearchResult,
+  highlighted: Boolean = false,
   isFavorite: Boolean = false,
   actions: ResultMenuActions = ResultMenuActions(),
   onClick: () -> Unit,
@@ -67,6 +69,10 @@ fun SearchResultItem(
         modifier =
           Modifier.fillMaxWidth()
             .then(
+              if (highlighted) Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
+              else Modifier
+            )
+            .then(
               if (result is SearchResult.IndexingIndicator) {
                 Modifier
               } else if (hasMenuItems) {
@@ -96,12 +102,7 @@ fun SearchResultItem(
               } else {
                 Modifier.size(40.dp)
               }
-            val imageBitmap =
-              remember(iconState) {
-                traceSection("SL:SearchResultItem.toImageBitmap:${result.namespace}") {
-                  iconState?.toImageBitmap()
-                }
-              }
+            val imageBitmap = rememberThemedIconBitmap(iconState)
             if (imageBitmap != null) {
               Image(
                 bitmap = imageBitmap,

--- a/app/src/main/res/drawable/ic_event.xml
+++ b/app/src/main/res/drawable/ic_event.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9AA0A6"
+        android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6C21,4.9 20.1,4 19,4zM19,20H5V10h14V20zM19,8H5V6h14V8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_file.xml
+++ b/app/src/main/res/drawable/ic_file.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9AA0A6"
+        android:pathData="M14,2H6C4.9,2 4.01,2.9 4.01,4L4,20c0,1.1 0.89,2 1.99,2H18c1.1,0 2,-0.9 2,-2V8L14,2zM16,18H8v-2h8V18zM16,14H8v-2h8V14zM13,9V3.5L18.5,9H13z"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_custom.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_custom.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/logo" />
     <foreground android:drawable="@android:color/transparent" />
+    <monochrome android:drawable="@drawable/ic_launcher_mark" />
 </adaptive-icon>

--- a/app/src/test/java/com/searchlauncher/app/data/CalendarIndexerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/CalendarIndexerTest.kt
@@ -1,0 +1,68 @@
+package com.searchlauncher.app.data
+
+import androidx.test.core.app.ApplicationProvider
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CalendarIndexerTest {
+
+  @Test
+  fun formatWhen_todayTomorrowAndAllDay() {
+    val now = startOfDay() + TimeUnit.HOURS.toMillis(10)
+    val todayAfternoon = startOfDay() + TimeUnit.HOURS.toMillis(15)
+    val tomorrowMorning = startOfDay() + TimeUnit.DAYS.toMillis(1) + TimeUnit.HOURS.toMillis(9)
+
+    assertEquals("Today · 15:00", CalendarIndexer.formatWhen(todayAfternoon, allDay = false, now))
+    assertEquals(
+      "Tomorrow · 09:00",
+      CalendarIndexer.formatWhen(tomorrowMorning, allDay = false, now),
+    )
+    assertEquals("Today · All day", CalendarIndexer.formatWhen(startOfDay(), allDay = true, now))
+  }
+
+  @Test
+  fun windowCoversAboutAWeek() {
+    val days = TimeUnit.MILLISECONDS.toDays(CalendarIndexer.WINDOW_MS)
+    assertEquals(8L, days)
+  }
+
+  @Test
+  fun documentFrom_opensTheEventAndKeepsLocationSearchable() {
+    val indexer = CalendarIndexer(ApplicationProvider.getApplicationContext())
+    val begin = startOfDay() + TimeUnit.HOURS.toMillis(14)
+    val doc =
+      indexer.documentFrom(
+        CalendarEntry(
+          eventId = 99L,
+          title = "Dentist",
+          beginMillis = begin,
+          allDay = false,
+          calendarName = "Personal",
+          location = "Utrecht",
+        )
+      )
+    assertEquals("calendar", doc.namespace)
+    assertEquals("99/$begin", doc.id)
+    assertEquals("Dentist", doc.name)
+    assertTrue(doc.intentUri!!.contains("99"))
+    assertTrue(doc.description!!.contains("Utrecht"))
+    assertTrue(doc.description!!.contains("Personal"))
+  }
+
+  private fun startOfDay(): Long {
+    val cal = Calendar.getInstance()
+    cal.set(Calendar.HOUR_OF_DAY, 0)
+    cal.set(Calendar.MINUTE, 0)
+    cal.set(Calendar.SECOND, 0)
+    cal.set(Calendar.MILLISECOND, 0)
+    return cal.timeInMillis
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/DownloadIndexerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/DownloadIndexerTest.kt
@@ -1,0 +1,52 @@
+package com.searchlauncher.app.data
+
+import androidx.test.core.app.ApplicationProvider
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DownloadIndexerTest {
+
+  @Test
+  fun formatSize_skipsEmptyAndFormatsBuckets() {
+    assertEquals(null, DownloadIndexer.formatSize(0))
+    assertEquals("512 B", DownloadIndexer.formatSize(512))
+    assertEquals("2 KB", DownloadIndexer.formatSize(2048))
+    assertEquals("1.5 MB", DownloadIndexer.formatSize((1.5 * 1024 * 1024).toLong()))
+  }
+
+  @Test
+  fun mimeLabel_mapsCommonTypes() {
+    assertEquals("PDF", DownloadIndexer.mimeLabel("application/pdf"))
+    assertEquals("Image", DownloadIndexer.mimeLabel("image/jpeg"))
+    assertEquals("Video", DownloadIndexer.mimeLabel("video/mp4"))
+    assertEquals("Archive", DownloadIndexer.mimeLabel("application/zip"))
+  }
+
+  @Test
+  fun documentFrom_putsContentUriAndSearchableSubtitle() {
+    val indexer = DownloadIndexer(ApplicationProvider.getApplicationContext())
+    val doc =
+      indexer.documentFrom(
+        DownloadEntry(
+          id = 42L,
+          displayName = "ticket.pdf",
+          mimeType = "application/pdf",
+          dateModifiedSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
+          sizeBytes = 2048,
+        )
+      )
+    assertEquals("downloads", doc.namespace)
+    assertEquals("42", doc.id)
+    assertEquals("ticket.pdf", doc.name)
+    assertTrue(doc.intentUri!!.contains("42"))
+    assertTrue(doc.description!!.startsWith("application/pdf|"))
+    assertTrue(doc.description!!.contains("PDF"))
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
@@ -101,6 +101,30 @@ class FavoriteKeysTest {
         )
         .isFavoritable()
     )
+    assertTrue(
+      SearchResult.Content(
+          id = "42",
+          namespace = "downloads",
+          title = "ticket.pdf",
+          subtitle = null,
+          icon = null,
+          packageName = "application/pdf",
+          deepLink = "content://media/external/downloads/42",
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.Content(
+          id = "9/1",
+          namespace = "calendar",
+          title = "Dentist",
+          subtitle = null,
+          icon = null,
+          packageName = "calendar",
+          deepLink = "content://com.android.calendar/events/9",
+        )
+        .isFavoritable()
+    )
     assertFalse(
       SearchResult.Content(
           id = "calc",

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -704,4 +704,92 @@ class SearchRepositoryTest {
       results.first().id,
     )
   }
+
+  @Test
+  fun `wrap includes download and calendar descriptions in searchable text`() {
+    val download =
+      repository.wrap(
+        AppSearchDocument(
+          namespace = "downloads",
+          id = "42",
+          score = 1,
+          name = "ticket",
+          description = "application/pdf|PDF · 2 KB",
+          intentUri = "content://media/external/downloads/42",
+        )
+      )
+    val event =
+      repository.wrap(
+        AppSearchDocument(
+          namespace = "calendar",
+          id = "9/1",
+          score = 1,
+          name = "Dentist",
+          description = "Tomorrow · 09:00 · Utrecht",
+          intentUri = "content://com.android.calendar/events/9",
+        )
+      )
+
+    assertEquals(10, download.namespaceInt)
+    assertTrue(download.nameLower.contains("pdf"))
+    assertEquals(11, event.namespaceInt)
+    assertTrue(event.nameLower.contains("utrecht"))
+  }
+
+  @Test
+  fun `search finds downloads by type and calendar events by location`() = runBlocking {
+    val download =
+      AppSearchDocument(
+        namespace = "downloads",
+        id = "42",
+        score = 1,
+        name = "ticket",
+        description = "application/pdf|PDF · 2 KB",
+        intentUri = "content://media/external/downloads/42",
+      )
+    val event =
+      AppSearchDocument(
+        namespace = "calendar",
+        id = "9/1",
+        score = 1,
+        name = "Dentist",
+        description = "Tomorrow · 09:00 · Utrecht",
+        intentUri = "content://com.android.calendar/events/9",
+      )
+    val app =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.example.clock",
+        score = 1,
+        name = "Clock",
+        intentUri = "intent://clock",
+      )
+
+    repository.documentSnapshot =
+      listOf(repository.wrap(app), repository.wrap(download), repository.wrap(event)).sortedBy {
+        it.namespaceInt
+      }
+
+    val pdfHits =
+      SearchRanker.rankCandidates(
+        "pdf",
+        repository.documentSnapshot,
+        includeSearchShortcuts = false,
+        usageStats = emptyMap(),
+        queryUsageStats = emptyMap(),
+        documentByNamespaceAndId = emptyMap(),
+      )
+    assertTrue(pdfHits.any { it.first.doc.namespace == "downloads" && it.first.doc.id == "42" })
+
+    val placeHits =
+      SearchRanker.rankCandidates(
+        "utrecht",
+        repository.documentSnapshot,
+        includeSearchShortcuts = false,
+        usageStats = emptyMap(),
+        queryUsageStats = emptyMap(),
+        documentByNamespaceAndId = emptyMap(),
+      )
+    assertTrue(placeHits.any { it.first.doc.namespace == "calendar" && it.first.doc.id == "9/1" })
+  }
 }

--- a/app/src/test/java/com/searchlauncher/app/ui/KeyShortcutsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/KeyShortcutsTest.kt
@@ -1,0 +1,41 @@
+package com.searchlauncher.app.ui
+
+import android.view.KeyEvent
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class KeyShortcutsTest {
+
+  @Test
+  fun matchesCtrlChordAndIgnoresOtherModifiers() {
+    val ctrlT = key(KeyEvent.KEYCODE_T, KeyEvent.META_CTRL_ON)
+    assertTrue(KeyShortcuts.matches(ctrlT, KeyEvent.KEYCODE_T, ctrl = true))
+    assertFalse(KeyShortcuts.matches(ctrlT, KeyEvent.KEYCODE_W, ctrl = true))
+    assertFalse(KeyShortcuts.matches(ctrlT, KeyEvent.KEYCODE_T, ctrl = false))
+
+    val ctrlShiftTab = key(KeyEvent.KEYCODE_TAB, KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON)
+    assertTrue(KeyShortcuts.matches(ctrlShiftTab, KeyEvent.KEYCODE_TAB, ctrl = true, shift = true))
+    assertFalse(
+      KeyShortcuts.matches(ctrlShiftTab, KeyEvent.KEYCODE_TAB, ctrl = true, shift = false)
+    )
+  }
+
+  @Test
+  fun matchesBareEscapeAndDpad() {
+    assertTrue(KeyShortcuts.matches(key(KeyEvent.KEYCODE_ESCAPE), KeyEvent.KEYCODE_ESCAPE))
+    assertTrue(KeyShortcuts.matches(key(KeyEvent.KEYCODE_DPAD_UP), KeyEvent.KEYCODE_DPAD_UP))
+    assertFalse(
+      KeyShortcuts.matches(
+        key(KeyEvent.KEYCODE_ESCAPE, action = KeyEvent.ACTION_UP),
+        KeyEvent.KEYCODE_ESCAPE,
+      )
+    )
+  }
+
+  private fun key(keyCode: Int, metaState: Int = 0, action: Int = KeyEvent.ACTION_DOWN): KeyEvent =
+    KeyEvent(0L, 0L, action, keyCode, 0, metaState)
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/ThemedIconsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ThemedIconsTest.kt
@@ -1,0 +1,58 @@
+package com.searchlauncher.app.ui
+
+import android.graphics.drawable.AdaptiveIconDrawable
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class ThemedIconsTest {
+
+  @Config(sdk = [33])
+  @Test
+  fun apply_tintsMonochromeLayerOnThemePlate() {
+    val mono = ColorDrawable(0xFFFFFFFF.toInt())
+    val adaptive =
+      AdaptiveIconDrawable(ColorDrawable(0xFF0000FF.toInt()), ColorDrawable(0xFF00FF00.toInt()))
+    // AdaptiveIconDrawable.monochrome is set via the third constructor on API 33+.
+    val withMono =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        AdaptiveIconDrawable(
+          ColorDrawable(0xFF0000FF.toInt()),
+          ColorDrawable(0xFF00FF00.toInt()),
+          mono,
+        )
+      } else {
+        adaptive
+      }
+
+    val themed =
+      ThemedIcons.apply(
+        withMono,
+        backgroundArgb = 0xFF112233.toInt(),
+        foregroundArgb = 0xFFEEEEEE.toInt(),
+      )
+    assertNotNull(themed)
+    assertTrue(themed is AdaptiveIconDrawable)
+  }
+
+  @Config(sdk = [33])
+  @Test
+  fun apply_leavesNonAdaptiveIconsAlone() {
+    val original = ColorDrawable(0xFF123456.toInt())
+    assertSame(original, ThemedIcons.apply(original, 0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
+  }
+
+  @Config(sdk = [30])
+  @Test
+  fun apply_isNoOpBeforeAndroid13() {
+    val original = ColorDrawable(0xFF123456.toInt())
+    assertSame(original, ThemedIcons.apply(original, 0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserFileChooserTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserFileChooserTest.kt
@@ -1,0 +1,30 @@
+package com.searchlauncher.app.ui.browser
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.webkit.ValueCallback
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserFileChooserTest {
+
+  @Test
+  fun start_returnsFalseWhenTheSystemPickerCannotRun() {
+    val chooser = BrowserFileChooser()
+    var cancelled = false
+    val callback = ValueCallback<Array<Uri>> { value -> if (value == null) cancelled = true }
+
+    assertFalse(chooser.start(callback, null))
+    assertTrue(cancelled)
+  }
+
+  @Test
+  fun deliver_isSafeWhenNoChooserIsOpen() {
+    BrowserFileChooser().deliver(Activity.RESULT_CANCELED, Intent())
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SearchLauncher already searched apps, contacts, shortcuts, and the web. This PR adds a few more on-device sources, fills in browser gaps, and makes the chrome usable with a hardware keyboard and on a tablet-sized window.

## Search Downloads
Files in the Downloads folder are indexed (up to 400, newest first) and searchable by name or type (`pdf`, `image`, …). Opening a result grants read permission on the MediaStore URI.

On Android 13+ the platform only surfaces media this app is allowed to see, plus files SearchLauncher itself downloaded. Other apps’ PDFs still need All files access, which this does not request.

## Search upcoming calendar events
With `READ_CALENDAR`, instances in the next ~8 days are indexed (max 200). Recurring events appear as the occurrences that actually fall in that window, not as one master event. Location and calendar name are searchable. Offered in onboarding and as a Settings permission row.

## Themed / monochrome icons
A Settings toggle tints other apps’ monochrome layers to the current theme (Android 13+). Apps without a monochrome layer stay as they are. SearchLauncher’s own adaptive icon now includes a monochrome mark, so the system can theme it the other way.

## Follow wallpaper colors
This was already on by default (`Auto from wallpaper`). The copy now says so, and extraction prefers a vibrant swatch over the muddy grey “dominant” color photos often produce.

## Browser file chooser
`WebChromeClient.onShowFileChooser` opens the system picker so `<input type="file">` works.

## Private Recents screenshots
Private browsing sets `FLAG_SECURE` and, on Android 13+, `setRecentsScreenshotEnabled(false)`, so the overview task does not show the page.

## Picture-in-picture video
Fullscreen HTML5 video can enter PiP when leaving the app. Works for the hosted browser in `MainActivity` and standalone `BrowserActivity`. Private browsing does not enter PiP. Home chrome is hidden while PiP is active.

## Keyboard and tablet
Hardware keyboard:

- Search: Escape, Ctrl/Cmd+L/K/F to focus, Up/Down to move the highlighted result (Enter/Go launches it)
- Browser: Ctrl+T/W/R/F/L/K, Ctrl+Tab / Ctrl+Shift+Tab, Escape

On tablets (`sw >= 600dp`) the search chrome, results, favorites, and settings sit in a centered 720dp column rather than stretching edge to edge. A two-pane settings screen, app-list grid, and split browser+search are noted as later options, not built here.

## Tests
`./gradlew test` (debug + release unit tests) passed, including new indexer, wrap/rank, themed-icon, shortcut, and file-chooser tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39eec99a-66f8-4761-96e6-09e23720c94e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39eec99a-66f8-4761-96e6-09e23720c94e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

