### PR TITLE
Unlock Private Space from search and the app drawer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:name="android.permission.BLUETOOTH_ADVERTISE"
         tools:targetApi="31" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
+    <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />

--- a/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
@@ -38,6 +38,7 @@ class AppIndexer(private val context: Context) {
       val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
       val seen = sortedSetOf<String>()
       for (profile in launcherApps.profiles) {
+        if (PrivateSpaceProfiles.isPrivate(launcherApps, profile)) continue
         for (info in launcherApps.getActivityList(null, profile)) {
           seen.add("${info.componentName.packageName}:${info.label}")
         }
@@ -62,9 +63,11 @@ class AppIndexer(private val context: Context) {
     // Apps are addressed by package id everywhere (search, favorites, history, the app list), so we
     // keep one document per package. A package can expose several launcher activities (e.g. Tasker)
     // or appear in multiple profiles, which would otherwise yield colliding ids.
+    // Private Space is skipped: those apps are live-queried and must vanish from search on lock.
     val seenPackages = mutableSetOf<String>()
 
     for (profile in launcherApps.profiles) {
+      if (PrivateSpaceProfiles.isPrivate(launcherApps, profile)) continue
       pauseCheck()
       try {
         // fetch activities directly per profile. This is more efficient and safer

--- a/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
@@ -55,7 +55,7 @@ val SearchResult.favoriteKey: String
 /** Whether this result can be pinned to the favorites row. */
 fun SearchResult.isFavoritable(): Boolean =
   when (this) {
-    is SearchResult.App,
+    is SearchResult.App -> !isPrivate
     is SearchResult.Contact,
     is SearchResult.Shortcut,
     is SearchResult.Snippet,
@@ -65,5 +65,6 @@ fun SearchResult.isFavoritable(): Boolean =
     // An open tab is a live view of the browser, not a thing to pin: it disappears when closed,
     // which would leave the favorite pointing at nothing.
     is SearchResult.BrowserTab,
-    is SearchResult.IndexingIndicator -> false
+    is SearchResult.IndexingIndicator,
+    is SearchResult.PrivateSpace -> false
   }

--- a/app/src/main/java/com/searchlauncher/app/data/PrivateSpace.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/PrivateSpace.kt
@@ -1,0 +1,72 @@
+package com.searchlauncher.app.data
+
+import android.content.ComponentName
+import android.content.pm.LauncherApps
+import android.os.Build
+import android.os.UserHandle
+import android.os.UserManager
+import com.searchlauncher.app.util.FuzzyMatch
+
+/**
+ * Live Private Space state. The durable AppSearch index never stores these apps; lock must be able
+ * to make them undiscoverable without waiting on a purge.
+ */
+data class PrivateSpaceSnapshot(
+  val available: Boolean = false,
+  val unlocked: Boolean = false,
+  val hideWhenLocked: Boolean = false,
+  val userHandle: UserHandle? = null,
+)
+
+data class PrivateAppInfo(
+  val packageName: String,
+  val label: String,
+  val componentName: ComponentName,
+  val userHandle: UserHandle,
+)
+
+object PrivateSpaceQuery {
+  const val CONTROL_ID = "private_space"
+  const val NAMESPACE = "private_space"
+  const val APP_ID_SUFFIX = "#private"
+
+  private val CONTROL_TARGETS =
+    listOf("private space", "unlock private space", "lock private space", "private")
+
+  fun showControl(available: Boolean, unlocked: Boolean, hideWhenLocked: Boolean): Boolean =
+    available && (unlocked || !hideWhenLocked)
+
+  fun showControl(snapshot: PrivateSpaceSnapshot): Boolean =
+    showControl(snapshot.available, snapshot.unlocked, snapshot.hideWhenLocked)
+
+  fun showApps(available: Boolean, unlocked: Boolean): Boolean = available && unlocked
+
+  fun showApps(snapshot: PrivateSpaceSnapshot): Boolean =
+    showApps(snapshot.available, snapshot.unlocked)
+
+  fun appId(packageName: String): String = "$packageName$APP_ID_SUFFIX"
+
+  fun controlScore(query: String): Int {
+    if (query.isBlank()) return 0
+    return CONTROL_TARGETS.maxOf { FuzzyMatch.calculateScore(query, it) }
+  }
+
+  fun includeControl(query: String): Boolean =
+    controlScore(query) > RankingScores.MIN_CANDIDATE_SCORE
+
+  fun appScore(query: String, label: String): Int = FuzzyMatch.calculateScore(query, label)
+
+  fun includeApp(query: String, label: String): Boolean =
+    appScore(query, label) > RankingScores.MIN_CANDIDATE_SCORE
+}
+
+object PrivateSpaceProfiles {
+  fun isPrivate(launcherApps: LauncherApps, user: UserHandle): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) return false
+    return try {
+      launcherApps.getLauncherUserInfo(user)?.userType == UserManager.USER_TYPE_PROFILE_PRIVATE
+    } catch (_: Exception) {
+      false
+    }
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/PrivateSpaceManager.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/PrivateSpaceManager.kt
@@ -1,0 +1,211 @@
+package com.searchlauncher.app.data
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.LauncherApps
+import android.content.pm.LauncherUserInfo
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.os.UserHandle
+import android.os.UserManager
+import android.util.Log
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Tracks Android 15 Private Space for the default home app: lock state, the unlock control, and the
+ * private-profile app list. Nothing here is written to AppSearch.
+ */
+class PrivateSpaceManager(private val context: Context) {
+  private val _snapshot = MutableStateFlow(PrivateSpaceSnapshot())
+  val snapshot: StateFlow<PrivateSpaceSnapshot> = _snapshot.asStateFlow()
+
+  private val _apps = MutableStateFlow<List<PrivateAppInfo>>(emptyList())
+  val apps: StateFlow<List<PrivateAppInfo>> = _apps.asStateFlow()
+
+  @Volatile private var started = false
+
+  private val profileReceiver =
+    object : BroadcastReceiver() {
+      override fun onReceive(context: Context?, intent: Intent?) {
+        refresh()
+      }
+    }
+
+  fun start() {
+    if (started) return
+    started = true
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      val filter =
+        IntentFilter().apply {
+          addAction(Intent.ACTION_PROFILE_AVAILABLE)
+          addAction(Intent.ACTION_PROFILE_UNAVAILABLE)
+        }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.registerReceiver(profileReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+      } else {
+        @Suppress("UnspecifiedRegisterReceiverFlag")
+        context.registerReceiver(profileReceiver, filter)
+      }
+    }
+    refresh()
+  }
+
+  fun refresh() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      _snapshot.value = PrivateSpaceSnapshot()
+      _apps.value = emptyList()
+      return
+    }
+    try {
+      refreshInternal()
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to refresh Private Space", e)
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+  private fun refreshInternal() {
+    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+    val userManager = context.getSystemService(UserManager::class.java)
+    val privateUser = findPrivateUser(launcherApps)
+    if (privateUser == null || userManager == null) {
+      _snapshot.value = PrivateSpaceSnapshot()
+      _apps.value = emptyList()
+      return
+    }
+
+    val userInfo = launcherApps.getLauncherUserInfo(privateUser)
+    val hideWhenLocked =
+      userInfo?.userConfig?.getBoolean(LauncherUserInfo.PRIVATE_SPACE_ENTRYPOINT_HIDDEN, false)
+        ?: false
+    val unlocked = !userManager.isQuietModeEnabled(privateUser)
+    _snapshot.value =
+      PrivateSpaceSnapshot(
+        available = true,
+        unlocked = unlocked,
+        hideWhenLocked = hideWhenLocked,
+        userHandle = privateUser,
+      )
+    _apps.value = if (unlocked) readPrivateApps(launcherApps, privateUser) else emptyList()
+  }
+
+  @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+  private fun findPrivateUser(launcherApps: LauncherApps): UserHandle? {
+    for (user in launcherApps.profiles) {
+      if (PrivateSpaceProfiles.isPrivate(launcherApps, user)) return user
+    }
+    return null
+  }
+
+  private fun readPrivateApps(launcherApps: LauncherApps, user: UserHandle): List<PrivateAppInfo> {
+    return try {
+      launcherApps.getActivityList(null, user).map { info ->
+        PrivateAppInfo(
+          packageName = info.componentName.packageName,
+          label = info.label.toString(),
+          componentName = info.componentName,
+          userHandle = info.user,
+        )
+      }
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to list Private Space apps", e)
+      emptyList()
+    }
+  }
+
+  /** [uiContext] should be an Activity so the system credential sheet can attach when unlocking. */
+  fun requestLocked(locked: Boolean, uiContext: Context) {
+    val user = _snapshot.value.userHandle ?: return
+    val userManager = uiContext.getSystemService(UserManager::class.java) ?: return
+    try {
+      userManager.requestQuietModeEnabled(locked, user)
+    } catch (e: Exception) {
+      Log.w(TAG, "requestQuietModeEnabled($locked) failed", e)
+    }
+  }
+
+  fun toggleLock(uiContext: Context) {
+    val snap = _snapshot.value
+    if (!snap.available || snap.userHandle == null) return
+    requestLocked(snap.unlocked, uiContext)
+  }
+
+  fun searchHits(query: String): List<SearchResult> {
+    val snap = _snapshot.value
+    if (!PrivateSpaceQuery.showControl(snap)) return emptyList()
+
+    val results = mutableListOf<SearchResult>()
+    if (PrivateSpaceQuery.includeControl(query)) {
+      controlResult(snap, PrivateSpaceQuery.controlScore(query))?.let { results.add(it) }
+    }
+    if (PrivateSpaceQuery.showApps(snap)) {
+      for (app in _apps.value) {
+        if (PrivateSpaceQuery.includeApp(query, app.label)) {
+          results.add(appResult(app, PrivateSpaceQuery.appScore(query, app.label)))
+        }
+      }
+    }
+    return results
+  }
+
+  fun controlResult(
+    snap: PrivateSpaceSnapshot = _snapshot.value,
+    matchScore: Int = RankingScores.NAMESPACE_BOOST_APPS,
+  ): SearchResult.PrivateSpace? {
+    if (!PrivateSpaceQuery.showControl(snap)) return null
+    return SearchResult.PrivateSpace(
+      id = PrivateSpaceQuery.CONTROL_ID,
+      namespace = PrivateSpaceQuery.NAMESPACE,
+      title = "Private Space",
+      subtitle = if (snap.unlocked) "Unlocked · tap to lock" else "Locked · tap to unlock",
+      icon = controlIcon(),
+      rankingScore = RankingScores.NAMESPACE_BOOST_APPS + matchScore,
+      unlocked = snap.unlocked,
+    )
+  }
+
+  fun appResults(): List<SearchResult.App> {
+    if (!PrivateSpaceQuery.showApps(_snapshot.value)) return emptyList()
+    return _apps.value.map { appResult(it, RankingScores.NAMESPACE_BOOST_APPS) }
+  }
+
+  private fun appResult(app: PrivateAppInfo, matchScore: Int): SearchResult.App {
+    return SearchResult.App(
+      id = PrivateSpaceQuery.appId(app.packageName),
+      namespace = "apps",
+      title = app.label,
+      subtitle = "Private",
+      icon = loadPrivateAppIcon(app),
+      rankingScore = RankingScores.NAMESPACE_BOOST_APPS + matchScore,
+      packageName = app.packageName,
+      isPrivate = true,
+      userHandle = app.userHandle,
+      componentName = app.componentName,
+    )
+  }
+
+  private fun loadPrivateAppIcon(app: PrivateAppInfo): Drawable? {
+    return try {
+      val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+      val info =
+        launcherApps.getActivityList(app.packageName, app.userHandle).firstOrNull {
+          it.componentName == app.componentName
+        } ?: launcherApps.getActivityList(app.packageName, app.userHandle).firstOrNull()
+      info?.getIcon(context.resources.displayMetrics.densityDpi)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun controlIcon(): Drawable? =
+    context.getDrawable(com.searchlauncher.app.R.drawable.ic_private_space)
+
+  companion object {
+    private const val TAG = "PrivateSpace"
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -291,6 +291,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private val snippetIndexer = SnippetIndexer(context)
   private val downloadIndexer = DownloadIndexer(context)
   private val calendarIndexer = CalendarIndexer(context)
+  val privateSpace = PrivateSpaceManager(context)
 
   private val _isInitialized = kotlinx.coroutines.flow.MutableStateFlow(false)
   val isInitialized: kotlinx.coroutines.flow.StateFlow<Boolean> = _isInitialized
@@ -370,6 +371,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           registerContactsObserver()
           registerCalendarObserver()
           registerDownloadsObserver()
+          privateSpace.start()
 
           // Pre-cache SearchLauncher's own icon for internal actions
           scope.launch {
@@ -1612,6 +1614,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     val launcherApps =
       context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as android.content.pm.LauncherApps
     for (profile in launcherApps.profiles) {
+      if (PrivateSpaceProfiles.isPrivate(launcherApps, profile)) continue
       try {
         if (launcherApps.isPackageEnabled(packageName, profile)) return true
       } catch (_: Exception) {
@@ -1634,12 +1637,14 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         android.util.Log.d("SearchRepository", "onPackageRemoved: $packageName")
         scheduleAppsRefresh(packageName)
         iconRepository.invalidateShortcutIcons(packageName)
+        privateSpace.refresh()
       }
 
       override fun onPackageAdded(packageName: String, user: android.os.UserHandle) {
         android.util.Log.d("SearchRepository", "onPackageAdded: $packageName")
         scheduleAppsRefresh(packageName)
         scope.launch { iconRepository.cacheAppIcon(packageName) }
+        privateSpace.refresh()
       }
 
       override fun onPackageChanged(packageName: String, user: android.os.UserHandle) {
@@ -1648,6 +1653,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           iconRepository.cacheAppIcon(packageName)
           iconRepository.invalidateShortcutIcons(packageName)
         }
+        privateSpace.refresh()
       }
 
       override fun onPackagesAvailable(
@@ -1657,6 +1663,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       ) {
         if (packageNames.isNullOrEmpty()) scheduleAppsRefresh()
         else packageNames.forEach { scheduleAppsRefresh(it) }
+        privateSpace.refresh()
       }
 
       override fun onPackagesUnavailable(
@@ -1666,6 +1673,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       ) {
         if (packageNames.isNullOrEmpty()) scheduleAppsRefresh()
         else packageNames.forEach { scheduleAppsRefresh(it) }
+        privateSpace.refresh()
       }
 
       override fun onShortcutsChanged(
@@ -1848,6 +1856,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               performInMemorySearch(query, excludedAliases, limit, includeSearchShortcuts)
             }
           results.addAll(indexResults)
+
+          results.addAll(
+            traceSection("SL:SearchRepository.privateSpace") { privateSpace.searchHits(query) }
+          )
 
           // 5. Suggestions (only when search shortcuts / suggestions are enabled)
           if (
@@ -2208,11 +2220,15 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               // Open tabs are transient and could not be rebuilt from a cache file anyway, so
               // they are never written to one.
               is SearchResult.BrowserTab -> return@forEach
+              is SearchResult.PrivateSpace -> return@forEach
             }
           obj.put("type", typeStr)
 
           when (res) {
-            is SearchResult.App -> obj.put("packageName", res.packageName)
+            is SearchResult.App -> {
+              if (res.isPrivate) return@forEach
+              obj.put("packageName", res.packageName)
+            }
             is SearchResult.Shortcut -> {
               obj.put("intentUri", res.intentUri)
               obj.put("packageName", res.packageName)
@@ -2232,7 +2248,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               obj.put("content", res.content)
             }
             is SearchResult.IndexingIndicator,
-            is SearchResult.BrowserTab -> {
+            is SearchResult.BrowserTab,
+            is SearchResult.PrivateSpace -> {
               // Nothing to store
             }
           }
@@ -2447,6 +2464,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         var iconCount = 0
 
         for (profile in profiles) {
+          if (PrivateSpaceProfiles.isPrivate(launcherApps, profile)) continue
           try {
             val activityList = launcherApps.getActivityList(null, profile)
             for (info in activityList) {
@@ -2482,6 +2500,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   suspend fun loadIcon(result: SearchResult): Drawable? =
     withContext(Dispatchers.IO) {
+      if (result is SearchResult.PrivateSpace || (result is SearchResult.App && result.isPrivate)) {
+        return@withContext result.icon
+      }
       val sdoc =
         documentSnapshot.find { it.doc.id == result.id && it.doc.namespace == result.namespace }
       if (sdoc == null) return@withContext null

--- a/app/src/main/java/com/searchlauncher/app/data/SearchResult.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchResult.kt
@@ -1,6 +1,8 @@
 package com.searchlauncher.app.data
 
+import android.content.ComponentName
 import android.graphics.drawable.Drawable
+import android.os.UserHandle
 
 sealed class SearchResult {
   abstract val id: String
@@ -18,6 +20,19 @@ sealed class SearchResult {
     override val icon: Drawable?,
     override val rankingScore: Int = 0,
     val packageName: String,
+    val isPrivate: Boolean = false,
+    val userHandle: UserHandle? = null,
+    val componentName: ComponentName? = null,
+  ) : SearchResult()
+
+  data class PrivateSpace(
+    override val id: String = PrivateSpaceQuery.CONTROL_ID,
+    override val namespace: String = PrivateSpaceQuery.NAMESPACE,
+    override val title: String,
+    override val subtitle: String?,
+    override val icon: Drawable?,
+    override val rankingScore: Int = 0,
+    val unlocked: Boolean,
   ) : SearchResult()
 
   data class Content(

--- a/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
@@ -32,6 +32,7 @@ class ShortcutIndexer(private val context: Context) {
     val appNameCache = mutableMapOf<String, String>()
 
     for (profile in launcherApps.profiles) {
+      if (PrivateSpaceProfiles.isPrivate(launcherApps, profile)) continue
       pauseCheck()
       for (packageName in packages) {
         pauseCheck()

--- a/app/src/main/java/com/searchlauncher/app/ui/AppListScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/AppListScreen.kt
@@ -57,6 +57,12 @@ fun AppListScreen(
   onBack: () -> Unit,
 ) {
   val apps by searchRepository.allApps.collectAsState(initial = emptyList())
+  val privateSnapshot by searchRepository.privateSpace.snapshot.collectAsState()
+  val privateAppInfos by searchRepository.privateSpace.apps.collectAsState()
+  val privateControl =
+    remember(privateSnapshot) { searchRepository.privateSpace.controlResult(privateSnapshot) }
+  val privateApps =
+    remember(privateSnapshot, privateAppInfos) { searchRepository.privateSpace.appResults() }
 
   val groupedApps =
     remember(apps) { apps.groupBy { it.title.firstOrNull()?.uppercaseChar() ?: '#' }.toSortedMap() }
@@ -136,7 +142,7 @@ fun AppListScreen(
         }
         .windowInsetsPadding(WindowInsets.statusBars)
   ) {
-    if (apps.isEmpty()) {
+    if (apps.isEmpty() && privateControl == null) {
       CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
     } else {
       LazyColumn(
@@ -163,6 +169,28 @@ fun AppListScreen(
             }
           }
           items(appList, key = { it.id }) { app ->
+            SearchResultItem(result = app, onClick = { onAppClick(app) })
+          }
+        }
+        if (privateControl != null) {
+          stickyHeader {
+            Box(
+              modifier =
+                Modifier.fillMaxWidth()
+                  .background(MaterialTheme.colorScheme.surface)
+                  .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+              Text(
+                text = "Private",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+              )
+            }
+          }
+          item(key = privateControl.id) {
+            SearchResultItem(result = privateControl, onClick = { onAppClick(privateControl) })
+          }
+          items(privateApps, key = { it.id }) { app ->
             SearchResultItem(result = app, onClick = { onAppClick(app) })
           }
         }

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.Prefs
+import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.ui.theme.SearchLauncherTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -1020,8 +1021,10 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
                 },
               )
               .launch(result, reportUsage = false)
-            currentScreenState = Screen.Search
-            clearQueryState()
+            if (result !is SearchResult.PrivateSpace) {
+              currentScreenState = Screen.Search
+              clearQueryState()
+            }
           },
           onBack = {
             currentScreenState = Screen.Search

--- a/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
@@ -43,6 +43,7 @@ class ResultLauncher(
   ) {
     when (result) {
       is SearchResult.App -> launchApp(result)
+      is SearchResult.PrivateSpace -> togglePrivateSpace()
       is SearchResult.Content -> launchContent(result, query)
       is SearchResult.Shortcut -> launchShortcut(result, query)
       is SearchResult.SearchIntent -> {
@@ -59,7 +60,11 @@ class ResultLauncher(
     // Tabs are skipped: their ids last only as long as the tab does, so recording usage against
     // one teaches the ranker nothing and grows the usage store without bound.
     if (
-      reportUsage && result !is SearchResult.IndexingIndicator && result !is SearchResult.BrowserTab
+      reportUsage &&
+        result !is SearchResult.IndexingIndicator &&
+        result !is SearchResult.BrowserTab &&
+        result !is SearchResult.PrivateSpace &&
+        !(result is SearchResult.App && result.isPrivate)
     ) {
       searchRepository.reportUsageAsync(result.namespace, result.id, query, wasFirstResult)
     }
@@ -90,11 +95,41 @@ class ResultLauncher(
   }
 
   private fun launchApp(result: SearchResult.App) {
+    if (result.isPrivate) {
+      launchPrivateApp(result)
+      return
+    }
     val launchIntent = context.packageManager.getLaunchIntentForPackage(result.packageName)
     launchIntent?.let {
       it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
       context.startActivity(it)
     }
+  }
+
+  private fun launchPrivateApp(result: SearchResult.App) {
+    val user = result.userHandle
+    if (user == null) {
+      Toast.makeText(context, "Private Space is locked", Toast.LENGTH_SHORT).show()
+      return
+    }
+    try {
+      val launcherApps =
+        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as android.content.pm.LauncherApps
+      val component =
+        result.componentName
+          ?: launcherApps.getActivityList(result.packageName, user).firstOrNull()?.componentName
+      if (component == null) {
+        Toast.makeText(context, "Cannot open ${result.title}", Toast.LENGTH_SHORT).show()
+        return
+      }
+      launcherApps.startMainActivity(component, user, null, null)
+    } catch (e: Exception) {
+      Toast.makeText(context, "Error opening ${result.title}", Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  private fun togglePrivateSpace() {
+    searchRepository.privateSpace.toggleLock(context)
   }
 
   private fun launchContent(result: SearchResult.Content, query: String) {

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -154,6 +154,7 @@ fun SearchScreen(
   val focusRequester = remember { FocusRequester() }
   val favoriteIds by app.favoritesRepository.favoriteIds.collectAsState()
   val isIndexing by searchRepository.isIndexing.collectAsState(initial = false)
+  val privateSpaceSnapshot by searchRepository.privateSpace.snapshot.collectAsState()
 
   val favorites by searchRepository.favorites.collectAsState()
   var showSnippetDialog by remember { mutableStateOf(false) }
@@ -736,7 +737,7 @@ fun SearchScreen(
     }
   }
 
-  LaunchedEffect(query, suggestionsEnabled, isIndexing, resultsRefreshTick) {
+  LaunchedEffect(query, suggestionsEnabled, isIndexing, resultsRefreshTick, privateSpaceSnapshot) {
     traceSection("SL:SearchScreen.queryEffect") {
       searchRepository.noteInteractiveSearch(query)
       if (query.isEmpty()) {

--- a/app/src/main/java/com/searchlauncher/app/ui/components/ResultContextMenu.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/ResultContextMenu.kt
@@ -91,7 +91,7 @@ internal fun ResultMenuActions.hasItemsFor(
 ): Boolean =
   result !is SearchResult.IndexingIndicator &&
     (result is SearchResult.Snippet ||
-      result is SearchResult.App ||
+      (result is SearchResult.App && !result.isPrivate) ||
       contactChatActions.isNotEmpty() ||
       onToggleFavorite != null ||
       onEditShortcut != null ||
@@ -218,7 +218,7 @@ internal fun ResultContextMenuItems(
     )
   }
 
-  if (result is SearchResult.App) {
+  if (result is SearchResult.App && !result.isPrivate) {
     AppActionsMenuItems(
       result = result,
       isFavorite = isFavorite,

--- a/app/src/main/res/drawable/ic_private_space.xml
+++ b/app/src/main/res/drawable/ic_private_space.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9AA0A6"
+        android:pathData="M18,8h-1V6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2H6c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8H8.9V6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
@@ -138,5 +138,25 @@ class FavoriteKeysTest {
         .isFavoritable()
     )
     assertFalse(SearchResult.IndexingIndicator().isFavoritable())
+    assertFalse(
+      SearchResult.App(
+          id = "com.example#private",
+          title = "Example",
+          subtitle = "Private",
+          icon = null,
+          packageName = "com.example",
+          isPrivate = true,
+        )
+        .isFavoritable()
+    )
+    assertFalse(
+      SearchResult.PrivateSpace(
+          title = "Private Space",
+          subtitle = "Locked · tap to unlock",
+          icon = null,
+          unlocked = false,
+        )
+        .isFavoritable()
+    )
   }
 }

--- a/app/src/test/java/com/searchlauncher/app/data/PrivateSpaceQueryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/PrivateSpaceQueryTest.kt
@@ -1,0 +1,74 @@
+package com.searchlauncher.app.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrivateSpaceQueryTest {
+
+  @Test
+  fun showControl_hiddenWhenLockedOmitsTheRow() {
+    assertFalse(
+      PrivateSpaceQuery.showControl(available = true, unlocked = false, hideWhenLocked = true)
+    )
+    assertTrue(
+      PrivateSpaceQuery.showControl(available = true, unlocked = true, hideWhenLocked = true)
+    )
+    assertTrue(
+      PrivateSpaceQuery.showControl(available = true, unlocked = false, hideWhenLocked = false)
+    )
+    assertFalse(
+      PrivateSpaceQuery.showControl(available = false, unlocked = false, hideWhenLocked = false)
+    )
+  }
+
+  @Test
+  fun showApps_onlyWhileUnlocked() {
+    assertFalse(PrivateSpaceQuery.showApps(available = true, unlocked = false))
+    assertTrue(PrivateSpaceQuery.showApps(available = true, unlocked = true))
+    assertFalse(PrivateSpaceQuery.showApps(available = false, unlocked = true))
+  }
+
+  @Test
+  fun appId_isProfileQualified() {
+    assertEquals("com.whatsapp#private", PrivateSpaceQuery.appId("com.whatsapp"))
+  }
+
+  @Test
+  fun includeControl_matchesPrivateAndLockWords() {
+    assertTrue(PrivateSpaceQuery.includeControl("private"))
+    assertTrue(PrivateSpaceQuery.includeControl("Private Space"))
+    assertTrue(PrivateSpaceQuery.includeControl("unlock"))
+    assertTrue(PrivateSpaceQuery.includeControl("lock"))
+  }
+
+  @Test
+  fun includeControl_doesNotMatchUnrelatedQueries() {
+    assertFalse(PrivateSpaceQuery.includeControl("whatsapp"))
+    assertFalse(PrivateSpaceQuery.includeControl("settings"))
+    assertFalse(PrivateSpaceQuery.includeControl(""))
+  }
+
+  @Test
+  fun includeApp_usesTheAppLabel() {
+    assertTrue(PrivateSpaceQuery.includeApp("photos", "Photos"))
+    assertTrue(PrivateSpaceQuery.includeApp("what", "WhatsApp"))
+    assertFalse(PrivateSpaceQuery.includeApp("photos", "WhatsApp"))
+  }
+
+  @Test
+  fun snapshotHelpers_agreeWithFlags() {
+    val locked = PrivateSpaceSnapshot(available = true, unlocked = false, hideWhenLocked = false)
+    val hiddenLocked =
+      PrivateSpaceSnapshot(available = true, unlocked = false, hideWhenLocked = true)
+    val unlocked = PrivateSpaceSnapshot(available = true, unlocked = true, hideWhenLocked = true)
+
+    assertTrue(PrivateSpaceQuery.showControl(locked))
+    assertFalse(PrivateSpaceQuery.showApps(locked))
+    assertFalse(PrivateSpaceQuery.showControl(hiddenLocked))
+    assertFalse(PrivateSpaceQuery.showApps(hiddenLocked))
+    assertTrue(PrivateSpaceQuery.showControl(unlocked))
+    assertTrue(PrivateSpaceQuery.showApps(unlocked))
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #103.

SearchLauncher is the default home app, so it is the only place Android will let a user enter Private Space. This adds the lock row Pixel users look for, without writing private app names into AppSearch.

## What you get
- A **Private Space** row in search (`private`, `unlock`, `lock`) and in a **Private** section at the bottom of the swipe-up app list.
- Tap while locked → system credential sheet. Tap while unlocked → lock immediately.
- While unlocked, private apps appear in that drawer section and as search hits with a **Private** subtitle. They launch with the private `UserHandle`.
- While locked, those apps are gone. If the user hid the space when locked, the row itself is omitted.
- Unlocking from the drawer keeps the list open so the private apps can appear.

## What we deliberately did not do
- Private apps are **not** indexed in AppSearch (lock must not depend on a purge).
- They are **not** pin-able or written to favorites/history caches.
- The personal A–Z list and durable index skip the private profile so lock/unlock cannot leak names.

Needs Android 15+ and SearchLauncher set as the default launcher (`ROLE_HOME` + `ACCESS_HIDDEN_PROFILES`). The Cloud AOSP emulator is API 30, so this was verified with unit tests; a Pixel is the realistic device test.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa9ac376-5fab-4f47-9ea3-dccf9d1f97ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa9ac376-5fab-4f47-9ea3-dccf9d1f97ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

