### PR TITLE
Auto-index ACTION_SEARCH destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ parses them straight out of that file. Bump both, add a changelog under
 
 ## Known Limitations
 
-- Content search within apps requires apps to implement AppSearch indexing
+- In-app search is auto-indexed for apps that declare `ACTION_SEARCH` / `SearchableInfo` (type `Settings wifi` to search Settings). Apps that do not opt in still cannot be queried from outside.
 - Content search within third-party apps requires those apps to expose indexable data
 
 ## Website

--- a/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
@@ -19,6 +19,7 @@ object FavoriteKeys {
       "web_saved",
       "downloads",
       "calendar",
+      "searchables",
     )
 
   fun of(namespace: String, id: String): String = "$namespace/$id"
@@ -61,7 +62,8 @@ fun SearchResult.isFavoritable(): Boolean =
     is SearchResult.Snippet,
     is SearchResult.SearchIntent -> true
     is SearchResult.Content ->
-      namespace in setOf("app_shortcuts", "web_saved", "web_bookmarks", "downloads", "calendar")
+      namespace in
+        setOf("app_shortcuts", "web_saved", "web_bookmarks", "downloads", "calendar", "searchables")
     // An open tab is a live view of the browser, not a thing to pin: it disappears when closed,
     // which would leave the favorite pointing at nothing.
     is SearchResult.BrowserTab,

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -41,6 +41,7 @@ object Prefs {
     const val CONTACTS_FINGERPRINT = "contacts_fingerprint"
     const val CALENDAR_FINGERPRINT = "calendar_fingerprint"
     const val DOWNLOADS_FINGERPRINT = "downloads_fingerprint"
+    const val SEARCHABLES_FINGERPRINT = "searchables_fingerprint"
     /** Persisted SAF grant for the Downloads folder; see [DownloadIndexer]. */
     const val DOWNLOADS_TREE_URI = "downloads_tree_uri"
   }

--- a/app/src/main/java/com/searchlauncher/app/data/RankingScores.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/RankingScores.kt
@@ -7,8 +7,8 @@ package com.searchlauncher.app.data
  * 1. Direct scores - smart actions, custom shortcuts, suggestions, widgets: a literal value chosen
  *    so the result lands at the desired position.
  * 2. Indexed scores - apps, app_shortcuts, snippets, shortcuts, contacts, calendar, downloads,
- *    web_saved, web_bookmarks: FuzzyMatch.calculateScore (0..100) + a namespace boost + optional
- *    context boost + usage.
+ *    web_saved, web_bookmarks, searchables: FuzzyMatch.calculateScore (0..100) + a namespace boost
+ *     + optional context boost + usage.
  *
  * Approximate descending order of typical scores: 1600 timer smart action; 1200 custom shortcut
  * with explicit search term ("g cats"); ~450-480 a page open in the browser; ~150-250 indexed hits,
@@ -74,6 +74,7 @@ object RankingScores {
   const val NAMESPACE_BOOST_CONTACTS = 40
   const val NAMESPACE_BOOST_CALENDAR = 90
   const val NAMESPACE_BOOST_DOWNLOADS = 50
+  const val NAMESPACE_BOOST_SEARCHABLES = 55
   const val NAMESPACE_BOOST_DEFAULT = 0
 
   // --- Context boosts stacked on top of the namespace boost ---

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
@@ -97,6 +97,7 @@ object SearchRanker {
         9 -> RankingScores.NAMESPACE_BOOST_WEB_SAVED
         10 -> RankingScores.NAMESPACE_BOOST_DOWNLOADS
         11 -> RankingScores.NAMESPACE_BOOST_CALENDAR
+        12 -> RankingScores.NAMESPACE_BOOST_SEARCHABLES
         else -> RankingScores.NAMESPACE_BOOST_DEFAULT
       }
 

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -861,10 +861,21 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private suspend fun indexSearchables(packageNames: List<String>? = null) =
     withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
+      android.util.Log.d("SearchRepository", "Indexing searchable activities...")
       val session = appSearchSession ?: return@withContext
-      val docs =
-        searchableIndexer.buildDocuments(::pauseIndexingIfSearchIsActive, packageNames)
-          ?: return@withContext
+      val docs = searchableIndexer.buildDocuments(::pauseIndexingIfSearchIsActive, packageNames)
+      if (docs == null) {
+        android.util.Log.w(
+          "SearchRepository",
+          "Searchable discovery failed; keeping existing index",
+        )
+        return@withContext
+      }
+      android.util.Log.d(
+        "SearchRepository",
+        if (packageNames == null) "Indexed ${docs.size} searchable activities"
+        else "Indexed ${docs.size} searchable activities for ${packageNames.size} package(s)",
+      )
 
       putDocuments(session, docs)
       if (packageNames == null) {

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -99,7 +99,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         doc.namespace == "snippets" ||
           doc.namespace == "app_shortcuts" ||
           doc.namespace == "downloads" ||
-          doc.namespace == "calendar"
+          doc.namespace == "calendar" ||
+          doc.namespace == SearchableIndexer.NAMESPACE
       ) {
         listOf(doc.name, doc.description.orEmpty()).joinToString(" ")
       } else {
@@ -123,6 +124,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         "web_saved" -> 9
         "downloads" -> 10
         "calendar" -> 11
+        SearchableIndexer.NAMESPACE -> 12
         else -> 0
       }
 
@@ -144,7 +146,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
       1,
       4,
-      6 -> { // apps, shortcuts, static_shortcuts
+      6,
+      12 -> { // apps, shortcuts, static_shortcuts, searchables
         packageName = doc.id.split("/").firstOrNull() ?: ""
       }
     }
@@ -291,6 +294,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private val snippetIndexer = SnippetIndexer(context)
   private val downloadIndexer = DownloadIndexer(context)
   private val calendarIndexer = CalendarIndexer(context)
+  private val searchableIndexer = SearchableIndexer(context)
 
   private val _isInitialized = kotlinx.coroutines.flow.MutableStateFlow(false)
   val isInitialized: kotlinx.coroutines.flow.StateFlow<Boolean> = _isInitialized
@@ -472,6 +476,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             refreshContactsIfChanged()
             refreshCalendarIfChanged()
             refreshDownloadsIfChanged()
+            refreshSearchablesIfChanged()
             return@launch
           }
 
@@ -713,6 +718,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       try {
         indexShortcuts(packageNames)
         indexStaticShortcuts(packageNames)
+        indexSearchables(packageNames)
       } catch (e: Exception) {
         android.util.Log.e("SearchRepository", "Error updating shortcuts after indexApps", e)
         Sentry.captureException(e)
@@ -848,6 +854,79 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           documentSnapshot = (filtered + docs.map { wrap(it) }).sortedBy { it.namespaceInt }
         }
       }
+    }
+
+  // packageNames: if null, full catalog rebuild; if provided, only those packages are queried
+  // and swapped. Searchable activities appear and disappear with the apps that declare them.
+  private suspend fun indexSearchables(packageNames: List<String>? = null) =
+    withContext(IndexingDispatchers.limited) {
+      pauseIndexingIfSearchIsActive()
+      val session = appSearchSession ?: return@withContext
+      val docs =
+        searchableIndexer.buildDocuments(::pauseIndexingIfSearchIsActive, packageNames)
+          ?: return@withContext
+
+      putDocuments(session, docs)
+      if (packageNames == null) {
+        removeMissingDocuments(session, SearchableIndexer.NAMESPACE, docs.map { it.id }.toSet())
+        replaceCollection(SearchableIndexer.NAMESPACE, docs)
+        searchableIndexer.readFingerprint()?.let {
+          context
+            .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString(Prefs.Launcher.SEARCHABLES_FINGERPRINT, it)
+            .apply()
+        }
+      } else {
+        val previousIds =
+          documentSnapshot
+            .asSequence()
+            .filter { sdoc ->
+              sdoc.doc.namespace == SearchableIndexer.NAMESPACE &&
+                packageNames.any { sdoc.doc.id.startsWith("$it/") }
+            }
+            .map { it.doc.id }
+            .toSet()
+        val keepIds = docs.map { it.id }.toSet()
+        val staleIds = previousIds - keepIds
+        if (staleIds.isNotEmpty()) {
+          try {
+            session
+              .removeAsync(
+                RemoveByDocumentIdRequest.Builder(SearchableIndexer.NAMESPACE)
+                  .addIds(staleIds)
+                  .build()
+              )
+              .await()
+          } catch (e: Exception) {
+            android.util.Log.e(
+              "SearchRepository",
+              "Failed to remove stale searchables for packages",
+              e,
+            )
+          }
+        }
+        synchronized(this@SearchRepository) {
+          val filtered =
+            documentSnapshot.filter { sdoc ->
+              sdoc.doc.namespace != SearchableIndexer.NAMESPACE ||
+                packageNames.none { sdoc.doc.id.startsWith("$it/") }
+            }
+          documentSnapshot = (filtered + docs.map { wrap(it) }).sortedBy { it.namespaceInt }
+        }
+      }
+    }
+
+  private suspend fun refreshSearchablesIfChanged() =
+    withContext(IndexingDispatchers.limited) {
+      val fingerprint = searchableIndexer.readFingerprint() ?: return@withContext
+      val prefs = context.getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      if (fingerprint == prefs.getString(Prefs.Launcher.SEARCHABLES_FINGERPRINT, null)) {
+        return@withContext
+      }
+
+      android.util.Log.d("SearchRepository", "Searchables changed while away, re-indexing")
+      indexWriteMutex.withLock { indexSearchables() }
     }
 
   /** Coalesces the burst of change notifications an account sync produces into one rebuild. */
@@ -1826,6 +1905,15 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           val matchedShortcut = customShortcutMatches.second
           results.addAll(customShortcutResults)
 
+          // 1b. ACTION_SEARCH destinations: "Settings wifi" → search that app for wifi
+          val searchableMatch =
+            if (matchedShortcut == null) {
+              findMatchingSearchable(query)
+            } else {
+              null
+            }
+          searchableMatch?.let { results.add(it) }
+
           // 2. Smart Actions
           val smartActions =
             traceSection("SL:SearchRepository.smartActions") {
@@ -1842,10 +1930,17 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               .filterIsInstance<SearchResult.SearchIntent>()
               .mapNotNull { it.trigger }
               .toSet()
+          val excludedSearchableIds = setOfNotNull(searchableMatch?.id)
 
           val indexResults =
             traceSection("SL:SearchRepository.performInMemorySearch") {
-              performInMemorySearch(query, excludedAliases, limit, includeSearchShortcuts)
+              performInMemorySearch(
+                query,
+                excludedAliases,
+                excludedSearchableIds,
+                limit,
+                includeSearchShortcuts,
+              )
             }
           results.addAll(indexResults)
 
@@ -2062,9 +2157,46 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     return results to shortcut
   }
 
+  /**
+   * If [query] is `{app name} {search term}` for an indexed searchable activity, return a
+   * high-priority result that launches that app's [android.content.Intent.ACTION_SEARCH] with the
+   * remainder as [android.app.SearchManager.QUERY]. Bare name matches are left to the index so the
+   * real app still ranks first.
+   */
+  internal fun findMatchingSearchable(query: String): SearchResult? {
+    var best: SearchableDocument? = null
+    var remainder: String? = null
+    for (sdoc in documentSnapshot) {
+      if (sdoc.doc.namespace != SearchableIndexer.NAMESPACE) continue
+      val after = SearchableIndexer.queryAfterLabel(query, sdoc.doc.name) ?: continue
+      if (after.isEmpty()) continue
+      if (best == null || sdoc.doc.name.length > best.doc.name.length) {
+        best = sdoc
+        remainder = after
+      }
+    }
+    val match = best ?: return null
+    remainder ?: return null
+    val component = SearchableIndexer.componentFromId(match.doc.id) ?: return null
+    val pkg = component.packageName
+    return SearchResult.Content(
+      id = match.doc.id,
+      namespace = SearchableIndexer.NAMESPACE,
+      title = "${match.doc.name}: $remainder",
+      subtitle = "App search",
+      icon = iconRepository.getMemory("appicon_$pkg"),
+      packageName = pkg,
+      deepLink =
+        SearchableIndexer.searchIntent(component, remainder)
+          .toUri(android.content.Intent.URI_INTENT_SCHEME),
+      rankingScore = RankingScores.CUSTOM_SHORTCUT_WITH_SEARCH_TERM,
+    )
+  }
+
   private suspend fun performInMemorySearch(
     query: String,
     excludedAliases: Set<String>,
+    excludedSearchableIds: Set<String>,
     limit: Int,
     includeSearchShortcuts: Boolean,
   ): List<SearchResult> {
@@ -2106,6 +2238,12 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           )
 
         if (searchResult is SearchResult.SearchIntent && searchResult.trigger in excludedAliases) {
+          continue
+        }
+        if (
+          searchResult.namespace == SearchableIndexer.NAMESPACE &&
+            searchResult.id in excludedSearchableIds
+        ) {
           continue
         }
 

--- a/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
@@ -1,6 +1,7 @@
 package com.searchlauncher.app.data
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.LauncherApps
 import android.graphics.Color
 import android.graphics.drawable.Drawable
@@ -44,6 +45,8 @@ class SearchResultFactory(
       "snippets" -> createSnippetResult(sdoc, rankingScore)
       "downloads" -> createDownloadResult(sdoc, rankingScore)
       "calendar" -> createCalendarResult(sdoc, rankingScore)
+      "searchables" ->
+        createSearchableResult(sdoc, rankingScore, query, saveToDisk, allowIpc, allowDisk)
       else -> createAppResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
     }
   }
@@ -274,6 +277,37 @@ class SearchResultFactory(
       // filters declare one. Only downloads put a MIME type here.
       packageName = "calendar",
       deepLink = doc.intentUri,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createSearchableResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    query: String?,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): SearchResult.Content {
+    val doc = sdoc.doc
+    val pkg = sdoc.packageName ?: doc.id.substringBefore('/')
+    val searchTerm = query?.let { SearchableIndexer.queryAfterLabel(it, doc.name) }.orEmpty()
+    val component = SearchableIndexer.componentFromId(doc.id)
+    val deepLink =
+      if (component != null) {
+        SearchableIndexer.searchIntent(component, searchTerm).toUri(Intent.URI_INTENT_SCHEME)
+      } else {
+        doc.intentUri
+      }
+
+    return SearchResult.Content(
+      id = doc.id,
+      namespace = SearchableIndexer.NAMESPACE,
+      title = if (searchTerm.isNotEmpty()) "${doc.name}: $searchTerm" else "Search ${doc.name}",
+      subtitle = if (searchTerm.isNotEmpty()) "App search" else (doc.description ?: "App search"),
+      icon = loadAppIcon(pkg, saveToDisk, allowIpc, allowDisk),
+      packageName = pkg,
+      deepLink = deepLink,
       rankingScore = rankingScore,
     )
   }

--- a/app/src/main/java/com/searchlauncher/app/data/SearchableIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchableIndexer.kt
@@ -1,0 +1,190 @@
+package com.searchlauncher.app.data
+
+import android.app.SearchManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+
+/**
+ * Discovers activities that accept [Intent.ACTION_SEARCH] and builds index documents for them.
+ *
+ * Two official surfaces are merged and de-duplicated by component:
+ * - [SearchManager.getSearchablesInGlobalSearch] (apps that opted into global search)
+ * - [PackageManager.queryIntentActivities] for [Intent.ACTION_SEARCH]
+ *
+ * These are not in-app content indexes. They are destinations that will open the app's own search
+ * UI with [SearchManager.QUERY] filled in when the user types a query after the app name.
+ */
+class SearchableIndexer(private val context: Context) {
+
+  /**
+   * Cheap summary of which searchable activities exist and what they are called. Null when the
+   * catalog cannot be read, which the caller should treat as "no answer" rather than "nothing
+   * changed".
+   */
+  fun readFingerprint(): String? {
+    return try {
+      val discovery = discover(packageNames = null)
+      if (!discovery.succeeded) return null
+      val seen = discovery.entries.map { "${it.component.flattenToString()}:${it.label}" }.sorted()
+      "${seen.size}/${seen.joinToString("|").hashCode()}"
+    } catch (e: Exception) {
+      android.util.Log.w(TAG, "Failed to read searchable fingerprint", e)
+      null
+    }
+  }
+
+  /**
+   * Returns one document per searchable activity. [pauseCheck] is invoked between entries so
+   * indexing yields to active searches.
+   *
+   * When [packageNames] is set, only those packages are queried. An empty filter returns nothing
+   * without walking the catalog. Returns null when discovery failed, so the caller can leave the
+   * existing index alone instead of wiping it.
+   */
+  suspend fun buildDocuments(
+    pauseCheck: suspend () -> Unit,
+    packageNames: Collection<String>? = null,
+  ): List<AppSearchDocument>? {
+    if (packageNames != null && packageNames.isEmpty()) return emptyList()
+
+    val discovery = discover(packageNames)
+    if (!discovery.succeeded) return null
+
+    val docs = ArrayList<AppSearchDocument>(discovery.entries.size)
+    for (entry in discovery.entries) {
+      pauseCheck()
+      docs.add(documentFrom(entry))
+    }
+    return docs
+  }
+
+  internal fun documentFrom(entry: SearchableActivity): AppSearchDocument {
+    return AppSearchDocument(
+      namespace = NAMESPACE,
+      id = entry.component.flattenToString(),
+      name = entry.label,
+      score = 1,
+      intentUri = searchIntent(entry.component, query = "").toUri(Intent.URI_INTENT_SCHEME),
+      description = entry.hint?.takeIf { it.isNotBlank() } ?: "Search in ${entry.label}",
+    )
+  }
+
+  private fun discover(packageNames: Collection<String>?): Discovery {
+    val searchManager = context.getSystemService(Context.SEARCH_SERVICE) as? SearchManager
+    val pm = context.packageManager
+    val seen = LinkedHashMap<String, SearchableActivity>()
+    var succeeded = false
+
+    fun add(component: ComponentName?, info: android.app.SearchableInfo?) {
+      if (component == null) return
+      if (component.packageName == context.packageName) return
+      if (packageNames != null && component.packageName !in packageNames) return
+      val key = component.flattenToString()
+      if (key in seen) return
+      val label = labelFor(pm, component) ?: return
+      seen[key] = SearchableActivity(component, label, hintFor(pm, info))
+    }
+
+    if (searchManager != null) {
+      try {
+        for (info in searchManager.searchablesInGlobalSearch) {
+          add(info.searchActivity, info)
+        }
+        succeeded = true
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "Failed reading global searchables", e)
+      }
+    }
+
+    try {
+      val intent = Intent(Intent.ACTION_SEARCH)
+      val flags = PackageManager.MATCH_ALL or PackageManager.GET_META_DATA
+      val resolves =
+        if (packageNames == null) {
+          pm.queryIntentActivities(intent, flags)
+        } else {
+          packageNames.flatMap { pkg ->
+            try {
+              pm.queryIntentActivities(Intent(intent).setPackage(pkg), flags)
+            } catch (_: Exception) {
+              emptyList()
+            }
+          }
+        }
+      for (resolve in resolves) {
+        val activity = resolve.activityInfo ?: continue
+        val component = ComponentName(activity.packageName, activity.name)
+        val info =
+          try {
+            searchManager?.getSearchableInfo(component)
+          } catch (_: Exception) {
+            null
+          }
+        add(component, info)
+      }
+      succeeded = true
+    } catch (e: Exception) {
+      android.util.Log.w(TAG, "Failed querying ACTION_SEARCH activities", e)
+    }
+
+    return Discovery(seen.values.toList(), succeeded)
+  }
+
+  private fun labelFor(pm: PackageManager, component: ComponentName): String? {
+    return try {
+      val info = pm.getApplicationInfo(component.packageName, 0)
+      pm.getApplicationLabel(info).toString().trim().takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun hintFor(pm: PackageManager, info: android.app.SearchableInfo?): String? {
+    if (info == null) return null
+    val resId = info.settingsDescriptionId
+    if (resId == 0) return null
+    return try {
+      pm
+        .getResourcesForApplication(info.searchActivity.packageName)
+        .getString(resId)
+        .trim()
+        .takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private data class Discovery(val entries: List<SearchableActivity>, val succeeded: Boolean)
+
+  companion object {
+    const val NAMESPACE = "searchables"
+    private const val TAG = "SearchableIndexer"
+
+    fun searchIntent(component: ComponentName, query: String): Intent {
+      return Intent(Intent.ACTION_SEARCH).apply {
+        this.component = component
+        putExtra(SearchManager.QUERY, query)
+      }
+    }
+
+    /**
+     * If [query] is [label] or starts with `[label] `, returns the remainder (possibly empty).
+     * Otherwise null — the query is not a searchable prefix for this label.
+     */
+    fun queryAfterLabel(query: String, label: String): String? {
+      val q = query.trim()
+      val l = label.trim()
+      if (l.isEmpty() || q.length < l.length) return null
+      if (!q.regionMatches(0, l, 0, l.length, ignoreCase = true)) return null
+      if (q.length == l.length) return ""
+      if (!q[l.length].isWhitespace()) return null
+      return q.substring(l.length).trim()
+    }
+
+    fun componentFromId(id: String): ComponentName? = ComponentName.unflattenFromString(id)
+  }
+}
+
+data class SearchableActivity(val component: ComponentName, val label: String, val hint: String?)

--- a/app/src/main/java/com/searchlauncher/app/data/SearchableIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchableIndexer.kt
@@ -50,7 +50,11 @@ class SearchableIndexer(private val context: Context) {
     if (packageNames != null && packageNames.isEmpty()) return emptyList()
 
     val discovery = discover(packageNames)
-    if (!discovery.succeeded) return null
+    if (!discovery.succeeded) {
+      android.util.Log.w(TAG, "Searchable discovery failed; leaving existing index in place")
+      return null
+    }
+    android.util.Log.d(TAG, "Discovered ${discovery.entries.size} searchable activities")
 
     val docs = ArrayList<AppSearchDocument>(discovery.entries.size)
     for (entry in discovery.entries) {
@@ -89,10 +93,12 @@ class SearchableIndexer(private val context: Context) {
 
     if (searchManager != null) {
       try {
-        for (info in searchManager.searchablesInGlobalSearch) {
+        val global = searchManager.searchablesInGlobalSearch
+        for (info in global) {
           add(info.searchActivity, info)
         }
         succeeded = true
+        android.util.Log.d(TAG, "Global searchables: ${global.size}")
       } catch (e: Exception) {
         android.util.Log.w(TAG, "Failed reading global searchables", e)
       }
@@ -113,6 +119,7 @@ class SearchableIndexer(private val context: Context) {
             }
           }
         }
+      android.util.Log.d(TAG, "ACTION_SEARCH activities: ${resolves.size}")
       for (resolve in resolves) {
         val activity = resolve.activityInfo ?: continue
         val component = ComponentName(activity.packageName, activity.name)

--- a/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
@@ -125,6 +125,18 @@ class FavoriteKeysTest {
         )
         .isFavoritable()
     )
+    assertTrue(
+      SearchResult.Content(
+          id = "com.android.settings/com.android.settings.SettingsSearch",
+          namespace = "searchables",
+          title = "Search Settings",
+          subtitle = null,
+          icon = null,
+          packageName = "com.android.settings",
+          deepLink = "intent:#Intent;action=android.intent.action.SEARCH;end",
+        )
+        .isFavoritable()
+    )
     assertFalse(
       SearchResult.Content(
           id = "calc",

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -706,7 +706,7 @@ class SearchRepositoryTest {
   }
 
   @Test
-  fun `wrap includes download and calendar descriptions in searchable text`() {
+  fun `wrap includes download calendar and searchable descriptions in searchable text`() {
     val download =
       repository.wrap(
         AppSearchDocument(
@@ -729,11 +729,25 @@ class SearchRepositoryTest {
           intentUri = "content://com.android.calendar/events/9",
         )
       )
+    val searchable =
+      repository.wrap(
+        AppSearchDocument(
+          namespace = "searchables",
+          id = "com.android.settings/com.android.settings.SettingsSearch",
+          score = 1,
+          name = "Settings",
+          description = "Wi-Fi, Bluetooth",
+          intentUri = "intent:#Intent;action=android.intent.action.SEARCH;end",
+        )
+      )
 
     assertEquals(10, download.namespaceInt)
     assertTrue(download.nameLower.contains("pdf"))
     assertEquals(11, event.namespaceInt)
     assertTrue(event.nameLower.contains("utrecht"))
+    assertEquals(12, searchable.namespaceInt)
+    assertEquals("com.android.settings", searchable.packageName)
+    assertTrue(searchable.nameLower.contains("wi-fi"))
   }
 
   @Test
@@ -791,5 +805,85 @@ class SearchRepositoryTest {
         documentByNamespaceAndId = emptyMap(),
       )
     assertTrue(placeHits.any { it.first.doc.namespace == "calendar" && it.first.doc.id == "9/1" })
+  }
+
+  @Test
+  fun `search finds searchable activities by hint text`() {
+    val searchable =
+      AppSearchDocument(
+        namespace = "searchables",
+        id = "com.android.settings/com.android.settings.SettingsSearch",
+        score = 1,
+        name = "Settings",
+        description = "Wi-Fi, Bluetooth",
+        intentUri = "intent:#Intent;action=android.intent.action.SEARCH;end",
+      )
+    repository.documentSnapshot = listOf(repository.wrap(searchable))
+
+    val hits =
+      SearchRanker.rankCandidates(
+        "bluetooth",
+        repository.documentSnapshot,
+        includeSearchShortcuts = false,
+        usageStats = emptyMap(),
+        queryUsageStats = emptyMap(),
+        documentByNamespaceAndId = emptyMap(),
+      )
+    assertTrue(
+      hits.any { it.first.doc.namespace == "searchables" && it.first.doc.id == searchable.id }
+    )
+  }
+
+  @Test
+  fun `settings wifi launches the settings searchable with that query`() = runBlocking {
+    val searchable =
+      AppSearchDocument(
+        namespace = "searchables",
+        id = "com.android.settings/com.android.settings.SettingsSearch",
+        score = 1,
+        name = "Settings",
+        description = "Wi-Fi, Bluetooth",
+        intentUri =
+          "intent:#Intent;action=android.intent.action.SEARCH;component=com.android.settings/.SettingsSearch;end",
+      )
+    val app =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.android.settings",
+        score = 2,
+        name = "Settings",
+        description = "Application",
+      )
+    repository.documentSnapshot =
+      listOf(repository.wrap(app), repository.wrap(searchable)).sortedBy { it.namespaceInt }
+
+    val results = repository.searchApps("Settings wifi", includeSuggestions = false).getOrThrow()
+    val match =
+      results.filterIsInstance<SearchResult.Content>().first { it.namespace == "searchables" }
+
+    assertEquals("Settings: wifi", match.title)
+    assertEquals(RankingScores.CUSTOM_SHORTCUT_WITH_SEARCH_TERM, match.rankingScore)
+    val intent =
+      android.content.Intent.parseUri(match.deepLink!!, android.content.Intent.URI_INTENT_SCHEME)
+    assertEquals(android.content.Intent.ACTION_SEARCH, intent.action)
+    assertEquals("wifi", intent.getStringExtra(android.app.SearchManager.QUERY))
+    assertEquals("com.android.settings", intent.component?.packageName)
+  }
+
+  @Test
+  fun `bare searchable name does not steal the app result`() {
+    val searchable =
+      AppSearchDocument(
+        namespace = "searchables",
+        id = "com.android.settings/com.android.settings.SettingsSearch",
+        score = 1,
+        name = "Settings",
+        description = "Wi-Fi, Bluetooth",
+        intentUri = "intent:#Intent;action=android.intent.action.SEARCH;end",
+      )
+    repository.documentSnapshot = listOf(repository.wrap(searchable))
+
+    assertEquals(null, repository.findMatchingSearchable("Settings"))
+    assertEquals(null, repository.findMatchingSearchable("setting"))
   }
 }

--- a/app/src/test/java/com/searchlauncher/app/data/SearchableIndexerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchableIndexerTest.kt
@@ -1,0 +1,86 @@
+package com.searchlauncher.app.data
+
+import android.app.SearchManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SearchableIndexerTest {
+
+  @Test
+  fun buildDocuments_emptyPackageFilterReturnsEmptyWithoutCatalogWalk() = runBlocking {
+    val indexer = SearchableIndexer(ApplicationProvider.getApplicationContext())
+
+    val docs = indexer.buildDocuments(pauseCheck = {}, packageNames = emptyList())
+
+    assertEquals(emptyList<AppSearchDocument>(), docs)
+  }
+
+  @Test
+  fun documentFrom_buildsActionSearchIntentForTheComponent() {
+    val indexer = SearchableIndexer(ApplicationProvider.getApplicationContext<Context>())
+    val component = ComponentName("com.android.settings", "com.android.settings.SettingsSearch")
+    val doc =
+      indexer.documentFrom(
+        SearchableActivity(component = component, label = "Settings", hint = "Wi‑Fi, Bluetooth")
+      )
+
+    assertEquals(SearchableIndexer.NAMESPACE, doc.namespace)
+    assertEquals(component.flattenToString(), doc.id)
+    assertEquals("Settings", doc.name)
+    assertEquals("Wi‑Fi, Bluetooth", doc.description)
+
+    val intent = Intent.parseUri(doc.intentUri!!, Intent.URI_INTENT_SCHEME)
+    assertEquals(Intent.ACTION_SEARCH, intent.action)
+    assertEquals(component, intent.component)
+    assertEquals("", intent.getStringExtra(SearchManager.QUERY))
+  }
+
+  @Test
+  fun documentFrom_fallsBackToSearchInLabelWhenHintIsMissing() {
+    val indexer = SearchableIndexer(ApplicationProvider.getApplicationContext<Context>())
+    val component = ComponentName("com.android.deskclock", "com.android.deskclock.Search")
+    val doc =
+      indexer.documentFrom(SearchableActivity(component = component, label = "Clock", hint = null))
+
+    assertEquals("Search in Clock", doc.description)
+  }
+
+  @Test
+  fun queryAfterLabel_requiresAFullLabelBoundary() {
+    assertEquals("", SearchableIndexer.queryAfterLabel("Settings", "Settings"))
+    assertEquals("wifi", SearchableIndexer.queryAfterLabel("settings wifi", "Settings"))
+    assertEquals("foo bar", SearchableIndexer.queryAfterLabel("Play Store foo bar", "Play Store"))
+    assertNull(SearchableIndexer.queryAfterLabel("Setting", "Settings"))
+    assertNull(SearchableIndexer.queryAfterLabel("SettingsFoo", "Settings"))
+    assertNull(SearchableIndexer.queryAfterLabel("clock", "Settings"))
+  }
+
+  @Test
+  fun searchIntent_putsTheQueryOnTheOfficialExtra() {
+    val component = ComponentName("com.example.app", "com.example.app.SearchActivity")
+    val intent = SearchableIndexer.searchIntent(component, "alarms")
+
+    assertEquals(Intent.ACTION_SEARCH, intent.action)
+    assertEquals(component, intent.component)
+    assertEquals("alarms", intent.getStringExtra(SearchManager.QUERY))
+  }
+
+  @Test
+  fun componentFromId_roundTripsFlattenedComponent() {
+    val component = ComponentName("com.android.settings", "com.android.settings.SettingsSearch")
+    assertEquals(component, SearchableIndexer.componentFromId(component.flattenToString()))
+    assertTrue(SearchableIndexer.componentFromId("not-a-component") == null)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Discover apps that declare Android’s official in-app search contract and make them queryable from the search bar.

## What this does
- Indexes `SearchManager.getSearchablesInGlobalSearch()` plus `ACTION_SEARCH` activities into a new `searchables` namespace
- Typing `{App name} {query}` (e.g. `Settings wifi`) launches that app’s search UI with `SearchManager.QUERY` set
- Bare app-name matches stay with the real app result; “Search Settings” appears as a separate indexed item
- Refreshes on package changes and via a fingerprint when the launcher was not running

## What this is not
This only finds apps that opted in (`searchable.xml` / `ACTION_SEARCH`). Instagram, Spotify, Gmail, etc. still will not appear unless they declare that contract. A curated shortcut catalog is the follow-up for those.

## Tests
- Unit tests: document/intent construction, label-prefix matching, ranking/searchable text, and `Settings wifi` → `ACTION_SEARCH` + `QUERY=wifi`
- Full `./gradlew test`: 159 debug unit tests, 0 failures
- AOSP 30 emulator: indexed **3** searchable activities (1 global searchable + 3 `ACTION_SEARCH` handlers). Contacts `PeopleActivity` opens from `ACTION_SEARCH`. Settings does **not** declare `ACTION_SEARCH` on this AOSP image.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a0c1f3a-8272-4bec-b851-9c7c9af0adef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a0c1f3a-8272-4bec-b851-9c7c9af0adef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

