### PR TITLE
Let the browser actually record after you allow the microphone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,12 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!--
+      Not a runtime permission, but Chromium's WebView audio pipeline will not expose a
+      capture device without it — getUserMedia then fails even after RECORD_AUDIO and
+      RESOURCE_AUDIO_CAPTURE have both been granted.
+    -->
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccess.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccess.kt
@@ -120,6 +120,8 @@ internal fun androidPermissionsFor(
   val permissions = linkedSetOf<String>()
   for (access in accesses) {
     when (access) {
+      // MODIFY_AUDIO_SETTINGS is also required for capture, but it is install-time only
+      // (see AndroidManifest) so it is never requested here.
       BrowserDeviceAccess.MICROPHONE -> permissions += Manifest.permission.RECORD_AUDIO
       BrowserDeviceAccess.CAMERA -> permissions += Manifest.permission.CAMERA
       BrowserDeviceAccess.LOCATION -> {

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
@@ -1,13 +1,19 @@
 package com.searchlauncher.app.ui.browser
 
 import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.webkit.PermissionRequest
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class BrowserDeviceAccessTest {
   @Test
   fun mapsKnownWebViewResources() {
@@ -103,6 +109,19 @@ class BrowserDeviceAccessTest {
       androidPermissionsFor(listOf(BrowserDeviceAccess.MICROPHONE, BrowserDeviceAccess.CAMERA))
         .toSet(),
     )
+  }
+
+  @Test
+  fun microphoneCaptureDeclaresModifyAudioSettings() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val requested =
+      context.packageManager
+        .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+        .requestedPermissions
+        .toSet()
+    // Chromium refuses to list a recording device unless both of these are in the manifest.
+    assertTrue(requested.contains(Manifest.permission.RECORD_AUDIO))
+    assertTrue(requested.contains(Manifest.permission.MODIFY_AUDIO_SETTINGS))
   }
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
@@ -1,19 +1,14 @@
 package com.searchlauncher.app.ui.browser
 
 import android.Manifest
-import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
 import android.webkit.PermissionRequest
-import androidx.test.core.app.ApplicationProvider
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class BrowserDeviceAccessTest {
   @Test
   fun mapsKnownWebViewResources() {
@@ -113,16 +108,14 @@ class BrowserDeviceAccessTest {
 
   @Test
   fun microphoneCaptureDeclaresModifyAudioSettings() {
-    val context = ApplicationProvider.getApplicationContext<Context>()
-    val requested =
-      context.packageManager
-        .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
-        .requestedPermissions
-        ?.toSet()
-        .orEmpty()
+    val manifest =
+      listOf("src/main/AndroidManifest.xml", "app/src/main/AndroidManifest.xml")
+        .map(::File)
+        .first { it.exists() }
+        .readText()
     // Chromium refuses to list a recording device unless both of these are in the manifest.
-    assertTrue(requested.contains(Manifest.permission.RECORD_AUDIO))
-    assertTrue(requested.contains(Manifest.permission.MODIFY_AUDIO_SETTINGS))
+    assertTrue(manifest.contains("android.permission.RECORD_AUDIO"))
+    assertTrue(manifest.contains("android.permission.MODIFY_AUDIO_SETTINGS"))
   }
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
@@ -118,7 +118,8 @@ class BrowserDeviceAccessTest {
       context.packageManager
         .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
         .requestedPermissions
-        .toSet()
+        ?.toSet()
+        .orEmpty()
     // Chromium refuses to list a recording device unless both of these are in the manifest.
     assertTrue(requested.contains(Manifest.permission.RECORD_AUDIO))
     assertTrue(requested.contains(Manifest.permission.MODIFY_AUDIO_SETTINGS))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The in-app prompt from #101 could grant `RECORD_AUDIO` and `RESOURCE_AUDIO_CAPTURE`, but Chromium’s WebView audio pipeline still refused to expose a capture device. `getUserMedia({ audio: true })` then failed even after Allow.

Chromium requires `MODIFY_AUDIO_SETTINGS` as well (install-time only; it is used to switch the stream into communication mode). That permission was missing from the manifest.

This adds it, documents why it is not requested at runtime, and asserts both permissions are declared so the gap cannot regress.

**Note on 0.0.18:** that release has no `onPermissionRequest` handler at all, so a tab’s microphone request is denied silently. 0.0.19 added the Allow prompt; this change is what makes capture actually work after you allow it.

**How to verify**
1. Open a tab on a getUserMedia test page (e.g. [permission.site](https://permission.site) or [WebRTC audio sample](https://webrtc.github.io/samples/src/content/getusermedia/audio/)).
2. Allow microphone when the site and OS prompts appear.
3. The page should receive an audio track instead of `NotFoundError` / `NotAllowedError`.

**Verified on aosp30**
- In-app “Use microphone?” dialog appears; Allow dismisses it and is remembered.
- Chromium console: `success microphone [object MediaStream]` (three times after Allow).
- No `Requires MODIFY_AUDIO_SETTINGS and RECORD_AUDIO` warning from the app process.

[permission.site in the in-app browser](https://cursor.com/agents/bc-fa35c7c2-3f8e-4bc4-a2d0-f1526e1d2b95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpermission_site_before_mic.png)
[browser_microphone_allow_and_capture.mp4](https://cursor.com/agents/bc-fa35c7c2-3f8e-4bc4-a2d0-f1526e1d2b95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser_microphone_allow_and_capture.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa35c7c2-3f8e-4bc4-a2d0-f1526e1d2b95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa35c7c2-3f8e-4bc4-a2d0-f1526e1d2b95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

