### PR TITLE
Show favorite search options when a query is entered

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/BackupManager.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/BackupManager.kt
@@ -80,6 +80,14 @@ class BackupManager(
           }
           writer.endArray()
 
+          writer.name("searchOptionFavorites")
+          writer.beginArray()
+          favoritesRepository.getSearchOptionIds().forEach { id ->
+            writer.value(id)
+            favoritesCount++
+          }
+          writer.endArray()
+
           // 4. Export History
           android.util.Log.d("BackupManager", "Exporting History...")
           writer.name("history")
@@ -260,6 +268,16 @@ class BackupManager(
             favoritesCount++
           }
           favoritesRepository.replaceAll(favorites)
+        }
+
+        if (backupData.has("searchOptionFavorites")) {
+          val searchOptionsArray = backupData.getJSONArray("searchOptionFavorites")
+          val searchOptions = mutableListOf<String>()
+          for (i in 0 until searchOptionsArray.length()) {
+            searchOptions.add(searchOptionsArray.getString(i))
+            favoritesCount++
+          }
+          favoritesRepository.replaceSearchOptions(searchOptions)
         }
 
         // 4. Import History

--- a/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
@@ -14,8 +14,13 @@ class FavoritesRepository(context: Context) {
   /** Ordered list of namespaced favorite keys (`namespace/id`). */
   val favoriteIds: StateFlow<List<String>> = _favoriteIds
 
+  private val _searchOptionIds = MutableStateFlow(SearchOptions.DEFAULT_FAVORITE_IDS)
+  /** Ordered shortcut ids shown in the query-time search-options bar. */
+  val searchOptionIds: StateFlow<List<String>> = _searchOptionIds
+
   init {
     loadFavorites()
+    loadSearchOptions()
   }
 
   private fun loadFavorites() {
@@ -96,6 +101,58 @@ class FavoritesRepository(context: Context) {
 
   fun clear() {
     _favoriteIds.value = emptyList()
-    prefs.edit().remove(Prefs.Favorites.IDS_ORDERED).remove(Prefs.Favorites.IDS).apply()
+    _searchOptionIds.value = SearchOptions.DEFAULT_FAVORITE_IDS
+    prefs
+      .edit()
+      .remove(Prefs.Favorites.IDS_ORDERED)
+      .remove(Prefs.Favorites.IDS)
+      .remove(Prefs.Favorites.SEARCH_OPTION_IDS)
+      .apply()
+  }
+
+  private fun loadSearchOptions() {
+    val jsonString = prefs.getString(Prefs.Favorites.SEARCH_OPTION_IDS, null) ?: return
+    try {
+      val array = JSONArray(jsonString)
+      _searchOptionIds.value =
+        (0 until array.length()).map { SearchOptions.normalizeId(array.getString(it)) }
+    } catch (e: Exception) {
+      e.printStackTrace()
+    }
+  }
+
+  fun toggleSearchOption(result: SearchResult) {
+    toggleSearchOption(SearchOptions.normalizeId(result.id))
+  }
+
+  fun toggleSearchOption(id: String) {
+    val normalized = SearchOptions.normalizeId(id)
+    val current = _searchOptionIds.value.toMutableList()
+    if (current.contains(normalized)) {
+      current.remove(normalized)
+    } else {
+      current.add(normalized)
+    }
+    replaceSearchOptions(current)
+  }
+
+  fun isSearchOptionFavorite(result: SearchResult): Boolean =
+    isSearchOptionFavorite(SearchOptions.normalizeId(result.id))
+
+  fun isSearchOptionFavorite(id: String): Boolean =
+    _searchOptionIds.value.contains(SearchOptions.normalizeId(id))
+
+  fun updateSearchOptionOrder(newOrder: List<String>) {
+    replaceSearchOptions(newOrder.map(SearchOptions::normalizeId))
+  }
+
+  fun getSearchOptionIds(): List<String> = _searchOptionIds.value
+
+  fun replaceSearchOptions(ids: List<String>) {
+    val normalized = ids.map(SearchOptions::normalizeId)
+    _searchOptionIds.value = normalized
+    val array = JSONArray()
+    normalized.forEach { array.put(it) }
+    prefs.edit().putString(Prefs.Favorites.SEARCH_OPTION_IDS, array.toString()).apply()
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -56,6 +56,8 @@ object Prefs {
     const val FILE = "favorites"
     const val IDS_ORDERED = "favorite_ids_ordered"
     const val IDS = "favorite_ids"
+    /** Ordered search-option ids shown in the query-time favorites bar. */
+    const val SEARCH_OPTION_IDS = "search_option_ids_ordered"
   }
 
   /** User-defined search shortcuts, stored as a JSON array. */

--- a/app/src/main/java/com/searchlauncher/app/data/SearchOptions.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchOptions.kt
@@ -1,0 +1,50 @@
+package com.searchlauncher.app.data
+
+/**
+ * The query-time favorites bar shows search destinations rather than pinned apps.
+ *
+ * Favorites are shortcut ids (`google`, `youtube`, …). Unknown or removed ids are skipped. Extra
+ * shortcuts fill whatever space is left so the row uses the full width.
+ */
+object SearchOptions {
+  val DEFAULT_FAVORITE_IDS = listOf("google", "youtube", "spotify")
+
+  /**
+   * Shortcut id from a stored value or a [SearchResult] key, with or without a `search_` prefix.
+   */
+  fun normalizeId(raw: String): String {
+    val id = FavoriteKeys.parse(raw)?.second ?: raw
+    return id.removePrefix("search_")
+  }
+
+  /**
+   * Splits [shortcuts] into pinned favorites (in [favoriteIds] order) and the remaining options
+   * that fill unused slots in the bar.
+   */
+  fun partition(
+    shortcuts: List<SearchShortcut>,
+    favoriteIds: List<String>,
+  ): Pair<List<SearchShortcut>, List<SearchShortcut>> {
+    val byId = shortcuts.associateBy { it.id }
+    val favorites = favoriteIds.map(SearchOptions::normalizeId).distinct().mapNotNull(byId::get)
+    val favoriteSet = favorites.map { it.id }.toSet()
+    val extras = shortcuts.filter { it.id !in favoriteSet }
+    return favorites to extras
+  }
+
+  /**
+   * The term to send to a search option. An alias prefix (`y cats`) is stripped so tapping Google
+   * still searches for `cats`, not `y cats`.
+   */
+  fun searchTerm(query: String, shortcuts: List<SearchShortcut>): String {
+    val trimmed = query.trimStart()
+    val match =
+      shortcuts.firstOrNull { trimmed.startsWith("${it.alias} ", ignoreCase = true) }
+        ?: shortcuts.firstOrNull { trimmed.equals(it.alias, ignoreCase = true) }
+    return when {
+      match == null -> query
+      trimmed.equals(match.alias, ignoreCase = true) -> ""
+      else -> trimmed.substring(match.alias.length).trimStart()
+    }
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/Shortcuts.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Shortcuts.kt
@@ -1,5 +1,7 @@
 package com.searchlauncher.app.data
 
+import android.graphics.drawable.Drawable
+
 /** User-editable search shortcuts with customizable aliases */
 data class SearchShortcut(
   val id: String, // Unique identifier
@@ -14,6 +16,20 @@ data class SearchShortcut(
   /** Fills [urlTemplate]'s `%s` placeholder with an encoded [query]. */
   fun urlForQuery(query: String): String =
     urlTemplate.replace("%s", java.net.URLEncoder.encode(query, "UTF-8"))
+
+  /**
+   * The same result the search list builds for this shortcut, including the coloured letter icon
+   * when [icon] is supplied by [SearchIconGenerator].
+   */
+  fun toSearchIntent(icon: Drawable? = null): SearchResult.SearchIntent =
+    SearchResult.SearchIntent(
+      id = id,
+      namespace = "search_shortcuts",
+      title = description,
+      subtitle = "Type '$alias ' to search",
+      icon = icon,
+      trigger = alias,
+    )
 }
 
 /** App-defined shortcuts that are not user-editable */

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -66,6 +66,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.edit
 import com.searchlauncher.app.data.Prefs
+import com.searchlauncher.app.data.SearchIconGenerator
+import com.searchlauncher.app.data.SearchOptions
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.SearchShortcut
@@ -153,6 +155,7 @@ fun SearchScreen(
   val scope = rememberCoroutineScope()
   val focusRequester = remember { FocusRequester() }
   val favoriteIds by app.favoritesRepository.favoriteIds.collectAsState()
+  val searchOptionIds by app.favoritesRepository.searchOptionIds.collectAsState()
   val isIndexing by searchRepository.isIndexing.collectAsState(initial = false)
   val privateSpaceSnapshot by searchRepository.privateSpace.snapshot.collectAsState()
 
@@ -166,6 +169,14 @@ fun SearchScreen(
   var showDefaultLauncherDialog by remember { mutableStateOf(false) }
   var showPrivacyPolicy by remember { mutableStateOf(false) }
   val searchShortcuts by app.searchShortcutRepository.items.collectAsState()
+  val iconGenerator = remember { SearchIconGenerator(context) }
+  val (searchOptionFavorites, searchOptionExtras) =
+    remember(searchShortcuts, searchOptionIds) {
+      val (favored, extras) = SearchOptions.partition(searchShortcuts, searchOptionIds)
+      fun intents(list: List<SearchShortcut>) =
+        list.map { it.toSearchIntent(iconGenerator.getColoredSearchIcon(it.color, it.alias)) }
+      intents(favored) to intents(extras)
+    }
   var showShortcutDialog by remember { mutableStateOf(false) }
   var bookmarkDialogTarget by remember { mutableStateOf<BookmarkDialogTarget?>(null) }
   // Bumped whenever something a result was built from changes — a bookmark's title, a tab being
@@ -955,7 +966,13 @@ fun SearchScreen(
 
   var chromeBarHeightPx by remember { mutableIntStateOf(0) }
   var favoritesRowHeightPx by remember { mutableIntStateOf(0) }
-  val favoritesRowVisible = query.isEmpty() && (favorites.isNotEmpty() || historyItems.isNotEmpty())
+  val showingSearchOptions = query.isNotBlank()
+  val favoritesRowVisible =
+    if (showingSearchOptions) {
+      searchOptionFavorites.isNotEmpty() || searchOptionExtras.isNotEmpty()
+    } else {
+      favorites.isNotEmpty() || historyItems.isNotEmpty()
+    }
   /** Everything pinned to the bottom of the home screen: the favorites row and the chrome bar. */
   val bottomSectionHeightPx =
     chromeBarHeightPx + if (favoritesRowVisible) favoritesRowHeightPx else 0
@@ -1634,32 +1651,89 @@ fun SearchScreen(
               modifier =
                 Modifier.contentMaxWidth().onSizeChanged { favoritesRowHeightPx = it.height }
             ) {
-              FavoritesRow(
-                favorites = favorites,
-                history = historyItems,
-                historyLimit = historyLimit,
-                minIconSizeSetting = minIconSizeSetting,
-                onLaunch = { result ->
-                  if (result is SearchResult.SearchIntent) {
-                    searchRepository.reportUsageAsync(result.namespace, result.id)
-                    onQueryChange(result.trigger + " ")
-                  } else {
-                    resultLauncher.launch(result, reportUsage = true)
-                    onDismiss()
-                  }
-                },
-                onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result) },
-                onReorder = { newOrder ->
-                  app.favoritesRepository.updateOrder(newOrder)
-                  scope.launch {
-                    onboardingManager.markStepComplete(OnboardingStep.ReorderFavorites)
-                  }
-                },
-                onCapacityChanged = { limit -> searchRepository.updateObservedHistoryLimit(limit) },
-                // The same menu the results list offers, so long-pressing an app here and long-
-                // pressing it in the results are the same gesture with the same answer.
-                menuActions = { result -> menuActionsFor(result, -1) },
-              )
+              if (showingSearchOptions) {
+                FavoritesRow(
+                  favorites = searchOptionFavorites,
+                  history = searchOptionExtras,
+                  minIconSizeSetting = minIconSizeSetting,
+                  expandToFill = true,
+                  reverseHistory = false,
+                  drawDivider = false,
+                  onLaunch = { result ->
+                    val intent = result as? SearchResult.SearchIntent
+                    val shortcut =
+                      searchShortcuts.find { it.id == result.id || it.alias == intent?.trigger }
+                    val term = SearchOptions.searchTerm(query, searchShortcuts)
+                    if (shortcut != null && intent != null && term.isNotBlank()) {
+                      launchShortcutSearch(
+                        context = context,
+                        searchRepository = searchRepository,
+                        shortcut = shortcut,
+                        result = intent,
+                        query = term,
+                        privateWebResults = privateWebResults,
+                        wasFirstResult = false,
+                        openInBrowser = { openInBrowser(it) },
+                        onDismiss = onDismiss,
+                      )
+                    } else if (intent != null) {
+                      searchRepository.reportUsageAsync(intent.namespace, intent.id)
+                      onQueryChange(intent.trigger + " ")
+                    }
+                  },
+                  onToggleFavorite = { result ->
+                    app.favoritesRepository.toggleSearchOption(result)
+                  },
+                  onReorder = { newOrder ->
+                    app.favoritesRepository.updateSearchOptionOrder(newOrder)
+                  },
+                  onCapacityChanged = {},
+                  menuActions = { result ->
+                    ResultMenuActions(
+                      onToggleFavorite = { app.favoritesRepository.toggleSearchOption(result) },
+                      onEditShortcut =
+                        if (result is SearchResult.SearchIntent) {
+                          {
+                            val shortcut = searchShortcuts.find { it.alias == result.trigger }
+                            if (shortcut != null) {
+                              editingShortcut = shortcut
+                              showShortcutDialog = true
+                            }
+                          }
+                        } else null,
+                    )
+                  },
+                )
+              } else {
+                FavoritesRow(
+                  favorites = favorites,
+                  history = historyItems,
+                  historyLimit = historyLimit,
+                  minIconSizeSetting = minIconSizeSetting,
+                  onLaunch = { result ->
+                    if (result is SearchResult.SearchIntent) {
+                      searchRepository.reportUsageAsync(result.namespace, result.id)
+                      onQueryChange(result.trigger + " ")
+                    } else {
+                      resultLauncher.launch(result, reportUsage = true)
+                      onDismiss()
+                    }
+                  },
+                  onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result) },
+                  onReorder = { newOrder ->
+                    app.favoritesRepository.updateOrder(newOrder)
+                    scope.launch {
+                      onboardingManager.markStepComplete(OnboardingStep.ReorderFavorites)
+                    }
+                  },
+                  onCapacityChanged = { limit ->
+                    searchRepository.updateObservedHistoryLimit(limit)
+                  },
+                  // The same menu the results list offers, so long-pressing an app here and
+                  // long-pressing it in the results are the same gesture with the same answer.
+                  menuActions = { result -> menuActionsFor(result, -1) },
+                )
+              }
               Spacer(modifier = Modifier.height(2.dp))
             }
           }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -49,6 +49,15 @@ fun FavoritesRow(
   onReorder: (List<String>) -> Unit,
   onCapacityChanged: (Int) -> Unit,
   /**
+   * Grow icons past the preferred size so the row uses the full width when there are fewer items
+   * than would fill it at [minIconSizeSetting].
+   */
+  expandToFill: Boolean = false,
+  /** History is newest-first and sits against the divider; set false to keep the given order. */
+  reverseHistory: Boolean = true,
+  /** Draw the gap between pinned items and the fill/history items. */
+  drawDivider: Boolean = true,
+  /**
    * What long-pressing an item offers. Supplied by callers that can answer for a result in full —
    * the search screen hands over the same one its results list uses, which is what makes the two
    * menus identical. Left out, an item offers only what this row can do by itself.
@@ -76,12 +85,12 @@ fun FavoritesRow(
 
     // Dynamically calculate how many history items we can actually fit
     val visibleHistory =
-      remember(favorites, history, totalWidthPx, historyLimit, minIconSizeSetting) {
+      remember(favorites, history, totalWidthPx, historyLimit, minIconSizeSetting, drawDivider) {
         val effectiveLimit =
           if (historyLimit >= 0) {
             historyLimit
           } else {
-            val showDividerInitial = favorites.isNotEmpty() && history.isNotEmpty()
+            val showDividerInitial = drawDivider && favorites.isNotEmpty() && history.isNotEmpty()
             val gapToReserve = if (showDividerInitial) dividerGapPx else 0f
 
             // Calculate max items that fit at min size
@@ -94,12 +103,13 @@ fun FavoritesRow(
           }
 
         onCapacityChanged(effectiveLimit)
-        history.take(effectiveLimit).reversed()
+        val visible = history.take(effectiveLimit)
+        if (reverseHistory) visible.reversed() else visible
       }
 
     val allItems = favorites + visibleHistory
     val boundaryIndex = favorites.size
-    val showDivider = favorites.isNotEmpty() && visibleHistory.isNotEmpty()
+    val showDivider = drawDivider && favorites.isNotEmpty() && visibleHistory.isNotEmpty()
 
     // State for dragging
     var draggedItemId by remember { mutableStateOf<String?>(null) }
@@ -170,7 +180,11 @@ fun FavoritesRow(
       if (totalCount > 0) (totalWidthPx - baseReservedSpace) / totalCount else 0f
     val preferredIconSizePx = with(density) { minIconSizeSetting.dp.toPx() }
     val finalIconSizePx =
-      minOf(preferredIconSizePx, if (calculatedSizePx > 0) calculatedSizePx else 1f)
+      when {
+        calculatedSizePx <= 0f -> 1f
+        expandToFill -> calculatedSizePx
+        else -> minOf(preferredIconSizePx, calculatedSizePx)
+      }
     val finalIconSize = with(density) { finalIconSizePx.toDp() }
 
     val itemWidthPx = finalIconSizePx + spacingPx

--- a/app/src/test/java/com/searchlauncher/app/data/FavoritesRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoritesRepositoryTest.kt
@@ -74,4 +74,47 @@ class FavoritesRepositoryTest {
       repo.getFavoriteIds(),
     )
   }
+
+  @Test
+  fun `search option favorites default to google youtube spotify`() {
+    val repo = FavoritesRepository(context)
+    assertEquals(SearchOptions.DEFAULT_FAVORITE_IDS, repo.getSearchOptionIds())
+  }
+
+  @Test
+  fun `toggleSearchOption persists and reloads`() {
+    val repo = FavoritesRepository(context)
+    val youtube =
+      SearchResult.SearchIntent(
+        id = "search_youtube",
+        namespace = "search_shortcuts",
+        title = "YouTube Search",
+        subtitle = null,
+        icon = null,
+        trigger = "y",
+      )
+
+    assertTrue(repo.isSearchOptionFavorite(youtube))
+    repo.toggleSearchOption(youtube)
+    assertEquals(listOf("google", "spotify"), repo.getSearchOptionIds())
+    assertFalse(repo.isSearchOptionFavorite(youtube))
+
+    val reloaded = FavoritesRepository(context)
+    assertEquals(listOf("google", "spotify"), reloaded.getSearchOptionIds())
+  }
+
+  @Test
+  fun `updateSearchOptionOrder normalizes keys`() {
+    val repo = FavoritesRepository(context)
+    repo.updateSearchOptionOrder(listOf("search_shortcuts/spotify", "search_youtube", "google"))
+    assertEquals(listOf("spotify", "youtube", "google"), repo.getSearchOptionIds())
+  }
+
+  @Test
+  fun `clear restores search option defaults`() {
+    val repo = FavoritesRepository(context)
+    repo.replaceSearchOptions(listOf("wikipedia"))
+    repo.clear()
+    assertEquals(SearchOptions.DEFAULT_FAVORITE_IDS, repo.getSearchOptionIds())
+  }
 }

--- a/app/src/test/java/com/searchlauncher/app/data/SearchOptionsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchOptionsTest.kt
@@ -1,0 +1,75 @@
+package com.searchlauncher.app.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchOptionsTest {
+  private val shortcuts = DefaultShortcuts.searchShortcuts
+
+  @Test
+  fun `defaults are google youtube spotify`() {
+    assertEquals(listOf("google", "youtube", "spotify"), SearchOptions.DEFAULT_FAVORITE_IDS)
+  }
+
+  @Test
+  fun `normalizeId strips namespace and search prefix`() {
+    assertEquals("google", SearchOptions.normalizeId("google"))
+    assertEquals("google", SearchOptions.normalizeId("search_google"))
+    assertEquals("google", SearchOptions.normalizeId("search_shortcuts/google"))
+    assertEquals("google", SearchOptions.normalizeId("search_shortcuts/search_google"))
+  }
+
+  @Test
+  fun `partition puts favorites first and fills with the rest`() {
+    val (favorites, extras) = SearchOptions.partition(shortcuts, SearchOptions.DEFAULT_FAVORITE_IDS)
+
+    assertEquals(listOf("google", "youtube", "spotify"), favorites.map { it.id })
+    assertTrue(extras.none { it.id in SearchOptions.DEFAULT_FAVORITE_IDS })
+    assertEquals(shortcuts.size, favorites.size + extras.size)
+    assertTrue(extras.isNotEmpty())
+  }
+
+  @Test
+  fun `partition skips unknown ids and keeps leftover shortcuts`() {
+    val (favorites, extras) =
+      SearchOptions.partition(shortcuts, listOf("google", "missing", "youtube"))
+
+    assertEquals(listOf("google", "youtube"), favorites.map { it.id })
+    assertTrue(extras.any { it.id == "spotify" })
+    assertTrue(extras.none { it.id == "google" || it.id == "youtube" })
+  }
+
+  @Test
+  fun `partition with empty favorites fills entirely from extras`() {
+    val (favorites, extras) = SearchOptions.partition(shortcuts, emptyList())
+
+    assertTrue(favorites.isEmpty())
+    assertEquals(shortcuts.map { it.id }, extras.map { it.id })
+  }
+
+  @Test
+  fun `searchTerm strips an alias prefix`() {
+    assertEquals("cats", SearchOptions.searchTerm("y cats", shortcuts))
+    assertEquals("cats", SearchOptions.searchTerm("g cats", shortcuts))
+    assertEquals("cats", SearchOptions.searchTerm("cats", shortcuts))
+  }
+
+  @Test
+  fun `searchTerm is empty for a bare alias`() {
+    assertEquals("", SearchOptions.searchTerm("y", shortcuts))
+    assertEquals("", SearchOptions.searchTerm("y ", shortcuts))
+  }
+
+  @Test
+  fun `toSearchIntent reuses the result-list identity and letter alias`() {
+    val youtube = shortcuts.first { it.id == "youtube" }
+    val result = youtube.toSearchIntent()
+
+    assertEquals("youtube", result.id)
+    assertEquals("search_shortcuts", result.namespace)
+    assertEquals("y", result.trigger)
+    assertEquals("YouTube Search", result.title)
+    assertEquals(0xFFFF0000L, youtube.color)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Typing a query hid the favorites bar. The only way to pick a search destination was to scroll to the appended shortcuts in the results list, or type an alias like `y cats`.

## Change

When the query is empty, the favorites row still shows pinned apps and history.

When the user types, that same bar switches to **favorite search options**:

- Defaults: Google, YouTube, Spotify
- Remaining shortcuts fill leftover slots so the row uses the full width
- Icons are the same coloured letter badges as in search results (red **Y** for YouTube, and so on)
- Tapping an option searches the current query there
- Long-press / drag still pins, unpins, and reorders — stored separately from app favorites

## Tests

- Unit tests for default ids, partition/fill order, alias-prefix search terms, and persistence
- `./gradlew :app:testDebugUnitTest spotlessCheck` passed
- Emulator: query `cats` filled the bar with G / Y / S first; tapping YouTube opened `https://m.youtube.com/results?search_query=cats`

[Search options bar for query cats](https://cursor.com/agents/bc-1d6bc946-e3c3-486b-a23e-352e510929de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquery_search_options_bar.png)
[YouTube results for cats after tapping Y](https://cursor.com/agents/bc-1d6bc946-e3c3-486b-a23e-352e510929de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_cats_results.png)
[query_shows_search_option_favorites.mp4](https://cursor.com/agents/bc-1d6bc946-e3c3-486b-a23e-352e510929de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquery_shows_search_option_favorites.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d6bc946-e3c3-486b-a23e-352e510929de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d6bc946-e3c3-486b-a23e-352e510929de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

