### PR TITLE
Show the keyboard with the search bar, without the empty well

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="stateAlwaysVisible|adjustNothing"
             android:theme="@style/Theme.SearchLauncher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -143,7 +143,8 @@
             android:exported="false"
             android:launchMode="singleTask"
             android:taskAffinity=""
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:windowSoftInputMode="stateAlwaysVisible|adjustNothing" />
 
         <!-- Search Widget -->
         <receiver android:name=".widget.SearchWidget"

--- a/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
+++ b/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
@@ -50,6 +50,8 @@ class SearchLauncherApp : Application() {
 
   override fun onCreate() {
     super.onCreate()
+    // Bind InputMethodManager now so the first keyboard show is not also a ServiceManager lookup.
+    getSystemService(Context.INPUT_METHOD_SERVICE)
     // The private browser gets an isolated WebView process/profile and must not initialize the
     // launcher's indexes, repositories, analytics, or other persistent application services.
     if (Application.getProcessName().endsWith(":incognito")) return

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -17,9 +17,12 @@ import androidx.core.view.WindowInsetsCompat
  * The IME is started by the system when a focused, text-capable view exists at the moment the
  * window gains focus. Compose's search field is often not that view yet: it is created a frame or
  * two later, and [InputMethodManager.SHOW_IMPLICIT] then drops the follow-up request because the
- * user just dismissed another app's keyboard. Show requests are explicit so they are not dropped,
- * and the home screen parks the chrome bar at a reserved height so it does not ride the IME
- * animation.
+ * user just dismissed another app's keyboard. Show requests are explicit so they are not dropped.
+ *
+ * Calling [show] again while the IME is already on its way restarts its appearance animation, so
+ * callers should treat a `true` return as "accepted" and wait rather than keep poking. Hiding from
+ * [Activity.onPause] is also avoided: that tears the IME process down, and the next home arrival
+ * then waits on a cold start.
  */
 object Ime {
 
@@ -45,9 +48,8 @@ object Ime {
   }
 
   /**
-   * Height the home screen should reserve for the keyboard, whether or not the IME has reported
-   * itself yet. Using the live inset here is what made the search bar hop: the IME animates from 0,
-   * and a dummy editor taking focus then giving it back made that animation run twice.
+   * Height to keep for the wallpaper while a tab is opening and the keys are on their way out. The
+   * chrome bar follows the live inset so it does not sit in mid-air above an empty keyboard well.
    */
   fun reservedHeightPx(storedPx: Int, containerHeightPx: Int): Int {
     if (containerHeightPx <= 0) return storedPx.coerceAtLeast(0)
@@ -58,22 +60,27 @@ object Ime {
       .coerceIn(MIN_PLAUSIBLE_HEIGHT_PX, maxPx.coerceAtLeast(MIN_PLAUSIBLE_HEIGHT_PX))
   }
 
-  fun show(view: View) {
+  /**
+   * Asks the IME to appear for [view]'s window. Returns true if the input method accepted the
+   * request (the keys may still be animating in). Returns false if this window cannot take the IME
+   * yet — not attached, not focused, or no editor to bind.
+   */
+  fun show(view: View): Boolean {
     if (!view.isAttachedToWindow) {
       view.post { if (view.isAttachedToWindow) show(view) }
-      return
+      return false
     }
     val activity = view.activityOrNull()
-    if (activity != null && !activity.hasWindowFocus()) return
+    if (activity != null && !activity.hasWindowFocus()) return false
     val window = view.windowOrNull()
-    if (window != null) {
-      WindowCompat.getInsetsController(window, view).show(WindowInsetsCompat.Type.ime())
-    }
     val target = window?.currentFocus ?: view
+    if (window != null) {
+      WindowCompat.getInsetsController(window, target).show(WindowInsetsCompat.Type.ime())
+    }
     val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     // Flags 0 is an explicit show, not SHOW_IMPLICIT (dropped after another app's keyboard was
     // dismissed) and not SHOW_FORCED (which keeps the IME up in the next activity).
-    imm.showSoftInput(target, 0)
+    return imm.showSoftInput(target, 0)
   }
 
   fun hide(view: View) {

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -3,7 +3,6 @@ package com.searchlauncher.app.ui
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
@@ -52,10 +51,9 @@ object Ime {
     }
     val target = window?.currentFocus ?: view
     val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    // SHOW_FORCED is ignored from API 33; the insets-controller call above is its replacement.
-    @Suppress("DEPRECATION")
-    val flags = if (Build.VERSION.SDK_INT < 33) InputMethodManager.SHOW_FORCED else 0
-    imm.showSoftInput(target, flags)
+    // Flags 0 is an explicit show, not SHOW_IMPLICIT (dropped after another app's keyboard was
+    // dismissed) and not SHOW_FORCED (which keeps the IME up in the next activity).
+    imm.showSoftInput(target, 0)
   }
 
   fun hide(view: View) {

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -48,6 +48,18 @@ object Ime {
   }
 
   /**
+   * IME inset to pad the chrome with. Live values larger than [MAX_HEIGHT_FRACTION] of the screen
+   * are the IME window reporting itself as full-screen while the keys are not; using them shoved
+   * the search bar off the top. Fall back to the stored height so the bar stays put for that frame.
+   */
+  fun insetForLayoutPx(imePx: Int, storedPx: Int, containerHeightPx: Int): Int {
+    if (containerHeightPx <= 0) return imePx.coerceAtLeast(0)
+    val maxPx = (containerHeightPx * MAX_HEIGHT_FRACTION).toInt()
+    if (imePx in 0..maxPx) return imePx
+    return reservedHeightPx(storedPx, containerHeightPx)
+  }
+
+  /**
    * Height to keep for the wallpaper while a tab is opening and the keys are on their way out. The
    * chrome bar follows the live inset so it does not sit in mid-air above an empty keyboard well.
    */
@@ -74,9 +86,9 @@ object Ime {
     if (activity != null && !activity.hasWindowFocus()) return false
     val window = view.windowOrNull()
     val target = window?.currentFocus ?: view
-    if (window != null) {
-      WindowCompat.getInsetsController(window, target).show(WindowInsetsCompat.Type.ime())
-    }
+    // Only [showSoftInput]. WindowInsetsController.show(ime()) also drives the Compose inset, and
+    // calling both (or calling either repeatedly) rewound the IME animation: the bar rode up over
+    // an empty IME window, dropped, then rose again when the keys finally drew.
     val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     // Flags 0 is an explicit show, not SHOW_IMPLICIT (dropped after another app's keyboard was
     // dismissed) and not SHOW_FORCED (which keeps the IME up in the next activity).

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -45,6 +45,8 @@ object Ime {
       view.post { if (view.isAttachedToWindow) show(view) }
       return
     }
+    val activity = view.activityOrNull()
+    if (activity != null && !activity.hasWindowFocus()) return
     val window = view.windowOrNull()
     if (window != null) {
       WindowCompat.getInsetsController(window, view).show(WindowInsetsCompat.Type.ime())
@@ -121,12 +123,14 @@ object Ime {
 
   internal fun warmupFor(activity: Activity): EditText? = warmups[activity]
 
-  private fun View.windowOrNull(): Window? {
+  private fun View.activityOrNull(): Activity? {
     var ctx = context
     while (ctx is ContextWrapper) {
-      if (ctx is Activity) return ctx.window
+      if (ctx is Activity) return ctx
       ctx = ctx.baseContext
     }
     return null
   }
+
+  private fun View.windowOrNull(): Window? = activityOrNull()?.window
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -1,0 +1,134 @@
+package com.searchlauncher.app.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import java.util.WeakHashMap
+
+/**
+ * Shows the software keyboard as soon as this window can take it.
+ *
+ * The IME is started by the system when a focused, text-capable view exists at the moment the
+ * window gains focus. Compose's search field is often not that view yet: it is created a frame or
+ * two later, and [InputMethodManager.SHOW_IMPLICIT] then drops the follow-up request because the
+ * user just dismissed another app's keyboard. A zero-size [EditText] is parked on the window until
+ * the real field takes over, and show requests are explicit so they are not dropped.
+ */
+object Ime {
+
+  /**
+   * Always-visible, and we pad for the IME ourselves. [setSoftInputMode] replaces the whole field,
+   * so both bits have to be set together or the manifest's adjust mode is lost.
+   */
+  const val SOFT_INPUT_MODE =
+    WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE or
+      WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+
+  private val warmups = WeakHashMap<Activity, EditText>()
+
+  fun applyWindowMode(window: Window) {
+    window.setSoftInputMode(SOFT_INPUT_MODE)
+  }
+
+  fun show(view: View) {
+    if (!view.isAttachedToWindow) {
+      view.post { if (view.isAttachedToWindow) show(view) }
+      return
+    }
+    val window = view.windowOrNull()
+    if (window != null) {
+      WindowCompat.getInsetsController(window, view).show(WindowInsetsCompat.Type.ime())
+    }
+    val target = window?.currentFocus ?: view
+    val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    // SHOW_FORCED is ignored from API 33; the insets-controller call above is its replacement.
+    @Suppress("DEPRECATION")
+    val flags = if (Build.VERSION.SDK_INT < 33) InputMethodManager.SHOW_FORCED else 0
+    imm.showSoftInput(target, flags)
+  }
+
+  fun hide(view: View) {
+    val window = view.windowOrNull()
+    if (window != null) {
+      WindowCompat.getInsetsController(window, view).hide(WindowInsetsCompat.Type.ime())
+    }
+    val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    imm.hideSoftInputFromWindow(view.windowToken, 0)
+  }
+
+  fun isVisible(view: View): Boolean =
+    ViewCompat.getRootWindowInsets(view)?.isVisible(WindowInsetsCompat.Type.ime()) == true
+
+  /**
+   * Parks a real editor on [activity] so the window already has something the IME can bind to
+   * before Compose has focused the search field. Released once that field takes focus.
+   */
+  fun installWarmup(activity: Activity) {
+    if (warmups.containsKey(activity)) return
+    val editor =
+      EditText(activity).apply {
+        layoutParams = ViewGroup.LayoutParams(0, 0)
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        isFocusable = true
+        isFocusableInTouchMode = true
+        showSoftInputOnFocus = true
+        isCursorVisible = false
+        setBackgroundColor(android.graphics.Color.TRANSPARENT)
+        imeOptions =
+          EditorInfo.IME_ACTION_GO or
+            EditorInfo.IME_FLAG_NO_FULLSCREEN or
+            EditorInfo.IME_FLAG_NO_EXTRACT_UI
+        inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+      }
+    (activity.window.decorView as ViewGroup).addView(editor)
+    editor.requestFocus()
+    editor.post { if (warmups[activity] === editor) editor.requestFocus() }
+    warmups[activity] = editor
+    if (activity.hasWindowFocus()) show(editor)
+  }
+
+  /**
+   * Called when the window itself has just taken focus. Re-asserts the warmup editor if Compose has
+   * not claimed focus yet, then asks the IME up on this same callback rather than on the next
+   * Compose frame.
+   */
+  fun onWindowFocused(activity: Activity) {
+    val warmup = warmups[activity]
+    if (warmup != null) {
+      warmup.requestFocus()
+      show(warmup)
+    } else {
+      val view = activity.window.currentFocus ?: activity.window.decorView
+      show(view)
+    }
+  }
+
+  fun releaseWarmup(activity: Activity) {
+    val editor = warmups.remove(activity) ?: return
+    editor.isFocusable = false
+    editor.isFocusableInTouchMode = false
+    (editor.parent as? ViewGroup)?.removeView(editor)
+  }
+
+  internal fun warmupFor(activity: Activity): EditText? = warmups[activity]
+
+  private fun View.windowOrNull(): Window? {
+    var ctx = context
+    while (ctx is ContextWrapper) {
+      if (ctx is Activity) return ctx.window
+      ctx = ctx.baseContext
+    }
+    return null
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -4,16 +4,12 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
-import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.EditText
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import java.util.WeakHashMap
 
 /**
  * Shows the software keyboard as soon as this window can take it.
@@ -21,8 +17,9 @@ import java.util.WeakHashMap
  * The IME is started by the system when a focused, text-capable view exists at the moment the
  * window gains focus. Compose's search field is often not that view yet: it is created a frame or
  * two later, and [InputMethodManager.SHOW_IMPLICIT] then drops the follow-up request because the
- * user just dismissed another app's keyboard. A zero-size [EditText] is parked on the window until
- * the real field takes over, and show requests are explicit so they are not dropped.
+ * user just dismissed another app's keyboard. Show requests are explicit so they are not dropped,
+ * and the home screen parks the chrome bar at a reserved height so it does not ride the IME
+ * animation.
  */
 object Ime {
 
@@ -34,10 +31,31 @@ object Ime {
     WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE or
       WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
 
-  private val warmups = WeakHashMap<Activity, EditText>()
+  /** Below this, a stored IME height is treated as missing rather than as a tiny keyboard. */
+  const val MIN_PLAUSIBLE_HEIGHT_PX = 101
+
+  /** Fraction of the window used as a stand-in until a real IME height has been measured. */
+  const val DEFAULT_HEIGHT_FRACTION = 0.36f
+
+  /** Hard ceiling: some IME windows report nearly the full screen while only the keys are not. */
+  const val MAX_HEIGHT_FRACTION = 0.5f
 
   fun applyWindowMode(window: Window) {
     window.setSoftInputMode(SOFT_INPUT_MODE)
+  }
+
+  /**
+   * Height the home screen should reserve for the keyboard, whether or not the IME has reported
+   * itself yet. Using the live inset here is what made the search bar hop: the IME animates from 0,
+   * and a dummy editor taking focus then giving it back made that animation run twice.
+   */
+  fun reservedHeightPx(storedPx: Int, containerHeightPx: Int): Int {
+    if (containerHeightPx <= 0) return storedPx.coerceAtLeast(0)
+    val maxPx = (containerHeightPx * MAX_HEIGHT_FRACTION).toInt()
+    if (storedPx in MIN_PLAUSIBLE_HEIGHT_PX..maxPx) return storedPx
+    return (containerHeightPx * DEFAULT_HEIGHT_FRACTION)
+      .toInt()
+      .coerceIn(MIN_PLAUSIBLE_HEIGHT_PX, maxPx.coerceAtLeast(MIN_PLAUSIBLE_HEIGHT_PX))
   }
 
   fun show(view: View) {
@@ -70,58 +88,10 @@ object Ime {
   fun isVisible(view: View): Boolean =
     ViewCompat.getRootWindowInsets(view)?.isVisible(WindowInsetsCompat.Type.ime()) == true
 
-  /**
-   * Parks a real editor on [activity] so the window already has something the IME can bind to
-   * before Compose has focused the search field. Released once that field takes focus.
-   */
-  fun installWarmup(activity: Activity) {
-    if (warmups.containsKey(activity)) return
-    val editor =
-      EditText(activity).apply {
-        layoutParams = ViewGroup.LayoutParams(0, 0)
-        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-        isFocusable = true
-        isFocusableInTouchMode = true
-        showSoftInputOnFocus = true
-        isCursorVisible = false
-        setBackgroundColor(android.graphics.Color.TRANSPARENT)
-        imeOptions =
-          EditorInfo.IME_ACTION_GO or
-            EditorInfo.IME_FLAG_NO_FULLSCREEN or
-            EditorInfo.IME_FLAG_NO_EXTRACT_UI
-        inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-      }
-    (activity.window.decorView as ViewGroup).addView(editor)
-    editor.requestFocus()
-    editor.post { if (warmups[activity] === editor) editor.requestFocus() }
-    warmups[activity] = editor
-    if (activity.hasWindowFocus()) show(editor)
-  }
-
-  /**
-   * Called when the window itself has just taken focus. Re-asserts the warmup editor if Compose has
-   * not claimed focus yet, then asks the IME up on this same callback rather than on the next
-   * Compose frame.
-   */
   fun onWindowFocused(activity: Activity) {
-    val warmup = warmups[activity]
-    if (warmup != null) {
-      warmup.requestFocus()
-      show(warmup)
-    } else {
-      val view = activity.window.currentFocus ?: activity.window.decorView
-      show(view)
-    }
+    val view = activity.window.currentFocus ?: activity.window.decorView
+    show(view)
   }
-
-  fun releaseWarmup(activity: Activity) {
-    val editor = warmups.remove(activity) ?: return
-    editor.isFocusable = false
-    editor.isFocusableInTouchMode = false
-    (editor.parent as? ViewGroup)?.removeView(editor)
-  }
-
-  internal fun warmupFor(activity: Activity): EditText? = warmups[activity]
 
   private fun View.activityOrNull(): Activity? {
     var ctx = context

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -477,8 +477,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     appWidgetHost = android.appwidget.AppWidgetHost(applicationContext, APPWIDGET_HOST_ID)
     queryState = savedInstanceState?.getString(KEY_ACTIVE_QUERY) ?: restoreRecentQuery()
     enableEdgeToEdge()
-    // Keep keyboard always visible
-    window.setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+    Ime.applyWindowMode(window)
 
     setContent {
       val themeColor =
@@ -526,6 +525,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
         Surface(modifier = Modifier.fillMaxSize(), color = backgroundColor) { MainScreen() }
       }
     }
+    Ime.installWarmup(this)
   }
 
   override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
@@ -586,18 +586,14 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     super.onResume()
     if (currentScreenState == Screen.Search) {
       focusTrigger = System.currentTimeMillis()
-      // Trigger again after delay for screen unlock scenarios
-      lifecycleScope.launch {
-        kotlinx.coroutines.delay(200)
-        focusTrigger = System.currentTimeMillis()
-      }
     }
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
-    if (hasFocus && currentScreenState == Screen.Search) {
+    if (hasFocus && currentScreenState == Screen.Search && !inPictureInPicture) {
       focusTrigger = System.currentTimeMillis()
+      Ime.onWindowFocused(this)
     }
   }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -589,6 +589,12 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     }
   }
 
+  override fun onPause() {
+    // Explicit hide so a SHOW_FORCED from the IME service cannot follow us into the next app.
+    Ime.hide(window.decorView)
+    super.onPause()
+  }
+
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
     if (hasFocus && currentScreenState == Screen.Search && !inPictureInPicture) {

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -525,7 +525,6 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
         Surface(modifier = Modifier.fillMaxSize(), color = backgroundColor) { MainScreen() }
       }
     }
-    Ime.installWarmup(this)
   }
 
   override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
@@ -598,7 +597,8 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
     if (hasFocus && currentScreenState == Screen.Search && !inPictureInPicture) {
-      focusTrigger = System.currentTimeMillis()
+      // Show here, but do not bump [focusTrigger]: that restarts the Compose IME loop and
+      // cancels the request that onResume already started.
       Ime.onWindowFocused(this)
     }
   }

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -588,17 +588,13 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     }
   }
 
-  override fun onPause() {
-    // Explicit hide so a SHOW_FORCED from the IME service cannot follow us into the next app.
-    Ime.hide(window.decorView)
-    super.onPause()
-  }
-
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
     if (hasFocus && currentScreenState == Screen.Search && !inPictureInPicture) {
       // Show here, but do not bump [focusTrigger]: that restarts the Compose IME loop and
-      // cancels the request that onResume already started.
+      // cancels the request that onResume already started. Do not hide in onPause either —
+      // that tears the IME process down, and the next home arrival waits on a cold start.
+      // Without SHOW_FORCED the keyboard leaves with this window's focus.
       Ime.onWindowFocused(this)
     }
   }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -96,11 +96,6 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
     if (hasFocus) Ime.onWindowFocused(this)
   }
 
-  override fun onPause() {
-    Ime.hide(window.decorView)
-    super.onPause()
-  }
-
   /**
    * Pushes whatever is behind this translucent window — the web page, the launcher — out of focus,
    * ramping the radius up so the backdrop settles along with the rest of the overlay instead of

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -36,10 +36,7 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
       android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
     )
 
-    window.setSoftInputMode(
-      android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING or
-        android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE
-    )
+    Ime.applyWindowMode(window)
 
     animateBackdropBlur()
 
@@ -92,6 +89,12 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
         riseWithKeyboard = true,
       )
     }
+    Ime.installWarmup(this)
+  }
+
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    super.onWindowFocusChanged(hasFocus)
+    if (hasFocus) Ime.onWindowFocused(this)
   }
 
   /**

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -89,7 +89,6 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
         riseWithKeyboard = true,
       )
     }
-    Ime.installWarmup(this)
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -97,6 +97,11 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
     if (hasFocus) Ime.onWindowFocused(this)
   }
 
+  override fun onPause() {
+    Ime.hide(window.decorView)
+    super.onPause()
+  }
+
   /**
    * Pushes whatever is behind this translucent window — the web page, the launcher — out of focus,
    * ramping the radius up so the backdrop settles along with the rest of the overlay instead of

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
@@ -728,19 +729,14 @@ fun SearchScreen(
     snapshotFlow { windowInfo.isWindowFocused }
       .collect { focused ->
         if (!focused || !shouldShowKeyboard.value) return@collect
-        repeat(12) {
-          if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@collect
+        var frames = 0
+        while (windowInfo.isWindowFocused && shouldShowKeyboard.value) {
           focusRequester.requestFocus()
           Ime.show(view)
-          if (Ime.isVisible(view)) return@collect
-          withFrameNanos {}
-        }
-        repeat(30) {
-          if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@collect
-          focusRequester.requestFocus()
-          Ime.show(view)
-          if (Ime.isVisible(view)) return@collect
-          kotlinx.coroutines.delay(50)
+          if (Ime.isVisible(view)) break
+          if (frames < 12) withFrameNanos {} else kotlinx.coroutines.delay(50)
+          frames++
+          if (frames > 200) break
         }
       }
   }
@@ -895,6 +891,7 @@ fun SearchScreen(
     context.getSharedPreferences(Prefs.Window.FILE, Context.MODE_PRIVATE)
   }
   val density = LocalDensity.current
+  val screenHeightPx = with(density) { LocalConfiguration.current.screenHeightDp.dp.roundToPx() }
   val imeHeightPx = WindowInsets.ime.getBottom(density)
 
   /**
@@ -906,8 +903,11 @@ fun SearchScreen(
    * the live inset. Some IME windows span nearly the whole screen while only their lower part is
    * keys, and a reading taken from one of those left the home screen squeezed into the top quarter
    * with a black band beneath it until the IME settled and overwrote it.
+   *
+   * Sized from the screen, not [androidx.compose.ui.platform.WindowInfo.containerSize]: that
+   * shrinks when the IME is up, which made the reserved height change and the bar jump.
    */
-  val maxPlausibleKeyboardPx = (windowInfo.containerSize.height * Ime.MAX_HEIGHT_FRACTION).toInt()
+  val maxPlausibleKeyboardPx = (screenHeightPx * Ime.MAX_HEIGHT_FRACTION).toInt()
 
   // Read synchronously for initial value. Do not clamp against a zero max on the first frame
   // (container size is often still 0), or a real stored height is thrown away and the bar jumps.
@@ -937,8 +937,7 @@ fun SearchScreen(
     }
   }
 
-  val reservedKeyboardHeightPx =
-    Ime.reservedHeightPx(storedKeyboardHeight, windowInfo.containerSize.height)
+  val reservedKeyboardHeightPx = Ime.reservedHeightPx(storedKeyboardHeight, screenHeightPx)
 
   // The effective padding is the max of current IME or stored IME height
   // In multi-window/floating mode, we ignore stored height to avoid unnecessary gaps

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -110,7 +110,6 @@ import com.searchlauncher.app.util.traceSection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -718,32 +717,32 @@ fun SearchScreen(
   // happens is what the system needs to start the keyboard on the same frame — waiting for
   // window focus first, then requesting, is a frame (or several) too late.
   //
-  // SHOW_IMPLICIT used to drop the request whenever the user had just come from another app
-  // (they dismissed that app's keyboard), so we kept poking every 120ms. Explicit show plus
-  // per-frame retries replace that delay.
+  // Keep asking until the IME is really visible. The process is often still starting after a
+  // handful of frames, and giving up there left the keyboard arriving a beat later on tap.
   val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
   val shouldShowKeyboard =
     rememberUpdatedState(isActive && !openingTab && !browserShowing && !inPip)
   LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip) {
-    if (!shouldShowKeyboard.value) {
-      (context as? android.app.Activity)?.let { Ime.releaseWarmup(it) }
-      return@LaunchedEffect
-    }
-    val activity = context as? android.app.Activity
-    fun takeFocus(): Boolean {
-      val focused = focusRequester.requestFocus()
-      if (focused) activity?.let { Ime.releaseWarmup(it) }
-      return focused
-    }
-    takeFocus()
-    snapshotFlow { windowInfo.isWindowFocused }.first { it }
-    repeat(8) {
-      if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@LaunchedEffect
-      takeFocus()
-      Ime.show(view)
-      if (Ime.isVisible(view)) return@LaunchedEffect
-      withFrameNanos {}
-    }
+    if (!shouldShowKeyboard.value) return@LaunchedEffect
+    focusRequester.requestFocus()
+    snapshotFlow { windowInfo.isWindowFocused }
+      .collect { focused ->
+        if (!focused || !shouldShowKeyboard.value) return@collect
+        repeat(12) {
+          if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@collect
+          focusRequester.requestFocus()
+          Ime.show(view)
+          if (Ime.isVisible(view)) return@collect
+          withFrameNanos {}
+        }
+        repeat(30) {
+          if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@collect
+          focusRequester.requestFocus()
+          Ime.show(view)
+          if (Ime.isVisible(view)) return@collect
+          kotlinx.coroutines.delay(50)
+        }
+      }
   }
 
   // Tapping the field when it is already focused produces no focus change, so nothing would
@@ -902,19 +901,18 @@ fun SearchScreen(
    * Ceiling on what we are willing to believe a keyboard measures.
    *
    * The height is remembered so the bar can hold the keyboard's place before the IME reports
-   * itself, but a bogus reading could get in there and stick: the space reserved below is the
-   * *larger* of the stored and live values, so anything too big survives every later correction.
-   * Some IME windows span nearly the whole screen while only their lower part is keys, and a
-   * reading taken from one of those left the home screen squeezed into the top quarter with a black
-   * band beneath it until the IME settled and overwrote it.
+   * itself. A bogus reading could get in there and stick, so anything larger than half the window
+   * is ignored when saving. The home screen then parks at that stored height rather than following
+   * the live inset. Some IME windows span nearly the whole screen while only their lower part is
+   * keys, and a reading taken from one of those left the home screen squeezed into the top quarter
+   * with a black band beneath it until the IME settled and overwrote it.
    */
-  val maxPlausibleKeyboardPx = (windowInfo.containerSize.height * 0.5f).toInt()
+  val maxPlausibleKeyboardPx = (windowInfo.containerSize.height * Ime.MAX_HEIGHT_FRACTION).toInt()
 
-  // Read synchronously for initial value
+  // Read synchronously for initial value. Do not clamp against a zero max on the first frame
+  // (container size is often still 0), or a real stored height is thrown away and the bar jumps.
   var storedKeyboardHeight by remember {
-    mutableStateOf(
-      sharedPrefs.getInt(Prefs.Window.KEYBOARD_HEIGHT, 0).coerceAtMost(maxPlausibleKeyboardPx)
-    )
+    mutableStateOf(sharedPrefs.getInt(Prefs.Window.KEYBOARD_HEIGHT, 0))
   }
 
   val isMultiWindow = (context as? android.app.Activity)?.isInMultiWindowMode == true
@@ -926,7 +924,11 @@ fun SearchScreen(
    * than sitting in mid-air until the browser finally takes over.
    */
   LaunchedEffect(imeHeightPx) {
-    if (imeHeightPx > 100 && imeHeightPx <= maxPlausibleKeyboardPx && !isMultiWindow) {
+    if (
+      imeHeightPx >= Ime.MIN_PLAUSIBLE_HEIGHT_PX &&
+        imeHeightPx <= maxPlausibleKeyboardPx &&
+        !isMultiWindow
+    ) {
       // Wait for animation to settle (debounce)
       kotlinx.coroutines.delay(300)
       // If we are still active (didn't get cancelled by new value), save it
@@ -934,6 +936,9 @@ fun SearchScreen(
       sharedPrefs.edit().putInt(Prefs.Window.KEYBOARD_HEIGHT, imeHeightPx).apply()
     }
   }
+
+  val reservedKeyboardHeightPx =
+    Ime.reservedHeightPx(storedKeyboardHeight, windowInfo.containerSize.height)
 
   // The effective padding is the max of current IME or stored IME height
   // In multi-window/floating mode, we ignore stored height to avoid unnecessary gaps
@@ -954,7 +959,10 @@ fun SearchScreen(
         // Follows the IME down frame by frame while a tab opens, so the bar rides the keyboard
         // out instead of dropping once it has gone.
         openingTab -> imeHeightPx.toDp()
-        else -> kotlin.math.max(imeHeightPx, storedKeyboardHeight).toDp()
+        // Parked, not live: following the inset made the bar ride the IME up, then down, then
+        // up again whenever input restarted (a dummy editor, a focus handoff). The keys fill
+        // space the bar already holds.
+        else -> reservedKeyboardHeightPx.toDp()
       }
     }
 
@@ -969,7 +977,7 @@ fun SearchScreen(
    */
   val wallpaperBottomPadding =
     if (openingTab) {
-      with(density) { kotlin.math.max(imeHeightPx, storedKeyboardHeight).toDp() }
+      with(density) { reservedKeyboardHeightPx.toDp() }
     } else {
       bottomPadding
     }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -738,6 +738,7 @@ fun SearchScreen(
     takeFocus()
     snapshotFlow { windowInfo.isWindowFocused }.first { it }
     repeat(8) {
+      if (!windowInfo.isWindowFocused || !shouldShowKeyboard.value) return@LaunchedEffect
       takeFocus()
       Ime.show(view)
       if (Ime.isVisible(view)) return@LaunchedEffect

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -975,17 +975,15 @@ fun SearchScreen(
   /**
    * What the wallpaper reserves at the bottom, which is not what the chrome bar reserves.
    *
-   * The bar follows the keyboard down frame by frame as a tab opens, so that it rides the keyboard
-   * out rather than dropping once it has gone. A full-screen picture cannot do that: the same
-   * padding shrinking under it resizes the image, and the wallpaper visibly grows during the very
-   * transition that is meant to be carrying it off to one side. So it keeps holding the keyboard's
-   * room throughout, exactly as it does at rest.
+   * The bar follows the live IME so it can rise with the keys. The picture cannot: the same padding
+   * changing under it resizes the image, which is the wallpaper sliding as the keyboard pops up.
+   * Home (and a tab opening) therefore keep the stored keyboard height whether the IME is up or
+   * not. The overlay has no wallpaper, so it can share the chrome inset.
    */
   val wallpaperBottomPadding =
-    if (openingTab) {
-      with(density) { reservedKeyboardHeightPx.toDp() }
-    } else {
-      bottomPadding
+    when {
+      riseWithKeyboard || isMultiWindow -> bottomPadding
+      else -> with(density) { reservedKeyboardHeightPx.toDp() }
     }
 
   var chromeBarHeightPx by remember { mutableIntStateOf(0) }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -738,16 +738,15 @@ fun SearchScreen(
         while (windowInfo.isWindowFocused && shouldShowKeyboard.value) {
           runCatching { focusRequester.requestFocus() }
           if (Ime.isVisible(view)) break
-          // A handful of explicit asks covers the editor not being ready on the first frame.
-          // After that, wait: showSoftInput and WindowInsetsController.show both restart the
-          // IME animation if they are issued while it is already coming up.
-          if (shows < 3) {
+          // One ask, then one retry after a few frames if the editor was not ready. More than
+          // that restarts the IME animation and the bar hops.
+          if (shows == 0 || (shows == 1 && attempts == 8)) {
             Ime.show(view)
             shows++
           }
           attempts++
           if (attempts > 200) break
-          if (shows < 3) withFrameNanos {} else kotlinx.coroutines.delay(50)
+          if (shows < 2 && attempts < 8) withFrameNanos {} else kotlinx.coroutines.delay(50)
         }
       }
   }
@@ -948,10 +947,11 @@ fun SearchScreen(
   }
 
   val reservedKeyboardHeightPx = Ime.reservedHeightPx(storedKeyboardHeight, screenHeightPx)
+  val imeForLayoutPx = Ime.insetForLayoutPx(imeHeightPx, storedKeyboardHeight, screenHeightPx)
 
-  // Chrome follows the live IME inset, including on home. Parking at a stored height put the
-  // bar in mid-air above an empty well until the keys caught up — and catching up took longer
-  // because the show loop kept restarting that same animation.
+  // Chrome follows the live IME inset, including on home. A stored-height park put the bar in
+  // mid-air above an empty well; a full-screen IME reading shoved it off the top. [imeForLayoutPx]
+  // is the live inset with those two cases stripped.
   val navigationBarBottomPx = WindowInsets.navigationBars.getBottom(density)
   val bottomPadding =
     with(density) {
@@ -961,14 +961,14 @@ fun SearchScreen(
         // without the bar hopping.
         riseWithKeyboard ->
           kotlin.math
-            .max(imeHeightPx, navigationBarBottomPx - BROWSER_CHROME_BAR_OFFSET.roundToPx())
+            .max(imeForLayoutPx, navigationBarBottomPx - BROWSER_CHROME_BAR_OFFSET.roundToPx())
             .coerceAtLeast(0)
             .toDp()
-        isMultiWindow -> imeHeightPx.toDp()
+        isMultiWindow -> imeForLayoutPx.toDp()
         // Follows the IME down frame by frame while a tab opens, so the bar rides the keyboard
         // out instead of dropping once it has gone.
-        openingTab -> imeHeightPx.toDp()
-        else -> kotlin.math.max(imeHeightPx, navigationBarBottomPx).toDp()
+        openingTab -> imeForLayoutPx.toDp()
+        else -> kotlin.math.max(imeForLayoutPx, navigationBarBottomPx).toDp()
       }
     }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -268,12 +269,6 @@ fun SearchScreen(
   val view = LocalView.current
   val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
 
-  // Use InputMethodManager for more reliable keyboard control
-  val imm = remember {
-    context.getSystemService(Context.INPUT_METHOD_SERVICE)
-      as android.view.inputmethod.InputMethodManager
-  }
-
   fun retractKeyboardForTab() {
     openingTab = true
     // Focus goes with it. Asking only the keyboard to leave was right when the browser was another
@@ -283,10 +278,7 @@ fun SearchScreen(
     // is what happened when a result was picked from the in-tab search and the page opened with the
     // keyboard still up.
     focusManager.clearFocus()
-    // Straight to the IMM like the rest of this screen's keyboard handling: the field keeps focus
-    // (the launcher is still the foreground app until the browser arrives), so only the keyboard
-    // itself is asked to go.
-    imm.hideSoftInputFromWindow(view.windowToken, 0)
+    Ime.hide(view)
   }
 
   // Every browser tab is a window of its own, so that the system's app switcher lists tabs the way
@@ -721,22 +713,35 @@ fun SearchScreen(
     }
   }
 
-  // Ask for the keyboard on activation. The IME can only be shown once the window actually
-  // holds focus — returning to the home screen often delivers focus late, so wait for it
-  // instead of guessing with fixed retries, then keep asking until the IME is really visible.
+  // Focus the field as soon as it exists, even before this window has focus. The IME can only
+  // actually appear once the window is focused, but an editor that is already focused when that
+  // happens is what the system needs to start the keyboard on the same frame — waiting for
+  // window focus first, then requesting, is a frame (or several) too late.
+  //
+  // SHOW_IMPLICIT used to drop the request whenever the user had just come from another app
+  // (they dismissed that app's keyboard), so we kept poking every 120ms. Explicit show plus
+  // per-frame retries replace that delay.
   val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
-  LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab) {
-    if (isActive && !openingTab && !browserShowing) {
-      snapshotFlow { windowInfo.isWindowFocused }.first { it }
-      repeat(10) {
-        focusRequester.requestFocus()
-        imm.showSoftInput(view, android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT)
-        kotlinx.coroutines.delay(120)
-        val imeVisible =
-          androidx.core.view.ViewCompat.getRootWindowInsets(view)
-            ?.isVisible(androidx.core.view.WindowInsetsCompat.Type.ime()) == true
-        if (imeVisible) return@LaunchedEffect
-      }
+  val shouldShowKeyboard =
+    rememberUpdatedState(isActive && !openingTab && !browserShowing && !inPip)
+  LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip) {
+    if (!shouldShowKeyboard.value) {
+      (context as? android.app.Activity)?.let { Ime.releaseWarmup(it) }
+      return@LaunchedEffect
+    }
+    val activity = context as? android.app.Activity
+    fun takeFocus(): Boolean {
+      val focused = focusRequester.requestFocus()
+      if (focused) activity?.let { Ime.releaseWarmup(it) }
+      return focused
+    }
+    takeFocus()
+    snapshotFlow { windowInfo.isWindowFocused }.first { it }
+    repeat(8) {
+      takeFocus()
+      Ime.show(view)
+      if (Ime.isVisible(view)) return@LaunchedEffect
+      withFrameNanos {}
     }
   }
 
@@ -747,7 +752,7 @@ fun SearchScreen(
     searchFieldInteractionSource.interactions.collect { interaction ->
       if (interaction is androidx.compose.foundation.interaction.PressInteraction.Release) {
         focusRequester.requestFocus()
-        imm.showSoftInput(view, android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT)
+        Ime.show(view)
       }
     }
   }
@@ -1850,18 +1855,25 @@ fun SearchScreen(
                 }
               },
               modifier =
-                Modifier.weight(1f).focusRequester(focusRequester).onKeyEvent { event ->
-                  if (
-                    event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
-                      displayQuery.isEmpty() &&
-                      activeShortcut != null
-                  ) {
-                    onQueryChange("")
-                    true
-                  } else {
-                    false
+                Modifier.weight(1f)
+                  .focusRequester(focusRequester)
+                  .onFocusChanged { state ->
+                    if (state.isFocused && shouldShowKeyboard.value) {
+                      Ime.show(view)
+                    }
                   }
-                },
+                  .onKeyEvent { event ->
+                    if (
+                      event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
+                        displayQuery.isEmpty() &&
+                        activeShortcut != null
+                    ) {
+                      onQueryChange("")
+                      true
+                    } else {
+                      false
+                    }
+                  },
               textStyle =
                 LocalTextStyle.current.copy(fontSize = 16.sp, color = LocalContentColor.current),
               // Autocorrect off keeps the query literal: package names, commands and URL fragments

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -141,9 +141,9 @@ fun SearchScreen(
   /** Moves only on a real home intent; [focusTrigger] also moves on any return of focus. */
   homeTrigger: Long = 0L,
   /**
-   * Let the chrome bar rise with the keyboard instead of reserving its height up front. Right for
-   * the search overlay, which opens as the keyboard comes up; the home screen keeps the space
-   * reserved so its layout doesn't shift underneath the user.
+   * Overlay-only inset tweak: the bar tracks the IME and sits a little over the nav bar. Home uses
+   * the same live inset without that overlap so the bar and keys travel together rather than the
+   * bar parking above an empty well.
    */
   riseWithKeyboard: Boolean = false,
 ) {
@@ -718,25 +718,36 @@ fun SearchScreen(
   // happens is what the system needs to start the keyboard on the same frame — waiting for
   // window focus first, then requesting, is a frame (or several) too late.
   //
-  // Keep asking until the IME is really visible. The process is often still starting after a
-  // handful of frames, and giving up there left the keyboard arriving a beat later on tap.
+  // Ask once the window can take it, then wait. Calling show again after the IME has accepted
+  // the request restarts its appearance animation, which is what made the keys land late and
+  // the bar hop as the inset rewound.
   val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
   val shouldShowKeyboard =
     rememberUpdatedState(isActive && !openingTab && !browserShowing && !inPip)
   LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip) {
-    if (!shouldShowKeyboard.value) return@LaunchedEffect
-    focusRequester.requestFocus()
+    if (!shouldShowKeyboard.value) {
+      Ime.hide(view)
+      return@LaunchedEffect
+    }
+    runCatching { focusRequester.requestFocus() }
     snapshotFlow { windowInfo.isWindowFocused }
       .collect { focused ->
         if (!focused || !shouldShowKeyboard.value) return@collect
-        var frames = 0
+        var shows = 0
+        var attempts = 0
         while (windowInfo.isWindowFocused && shouldShowKeyboard.value) {
-          focusRequester.requestFocus()
-          Ime.show(view)
+          runCatching { focusRequester.requestFocus() }
           if (Ime.isVisible(view)) break
-          if (frames < 12) withFrameNanos {} else kotlinx.coroutines.delay(50)
-          frames++
-          if (frames > 200) break
+          // A handful of explicit asks covers the editor not being ready on the first frame.
+          // After that, wait: showSoftInput and WindowInsetsController.show both restart the
+          // IME animation if they are issued while it is already coming up.
+          if (shows < 3) {
+            Ime.show(view)
+            shows++
+          }
+          attempts++
+          if (attempts > 200) break
+          if (shows < 3) withFrameNanos {} else kotlinx.coroutines.delay(50)
         }
       }
   }
@@ -897,15 +908,14 @@ fun SearchScreen(
   /**
    * Ceiling on what we are willing to believe a keyboard measures.
    *
-   * The height is remembered so the bar can hold the keyboard's place before the IME reports
-   * itself. A bogus reading could get in there and stick, so anything larger than half the window
-   * is ignored when saving. The home screen then parks at that stored height rather than following
-   * the live inset. Some IME windows span nearly the whole screen while only their lower part is
-   * keys, and a reading taken from one of those left the home screen squeezed into the top quarter
-   * with a black band beneath it until the IME settled and overwrote it.
+   * The height is remembered so the wallpaper can keep its crop while a tab opens and the keys
+   * retract. A bogus reading could get in there and stick, so anything larger than half the window
+   * is ignored when saving. Some IME windows span nearly the whole screen while only their lower
+   * part is keys, and a reading taken from one of those left the home screen squeezed into the top
+   * quarter with a black band beneath it until the IME settled and overwrote it.
    *
    * Sized from the screen, not [androidx.compose.ui.platform.WindowInfo.containerSize]: that
-   * shrinks when the IME is up, which made the reserved height change and the bar jump.
+   * shrinks when the IME is up.
    */
   val maxPlausibleKeyboardPx = (screenHeightPx * Ime.MAX_HEIGHT_FRACTION).toInt()
 
@@ -939,16 +949,16 @@ fun SearchScreen(
 
   val reservedKeyboardHeightPx = Ime.reservedHeightPx(storedKeyboardHeight, screenHeightPx)
 
-  // The effective padding is the max of current IME or stored IME height
-  // In multi-window/floating mode, we ignore stored height to avoid unnecessary gaps
+  // Chrome follows the live IME inset, including on home. Parking at a stored height put the
+  // bar in mid-air above an empty well until the keys caught up — and catching up took longer
+  // because the show loop kept restarting that same animation.
   val navigationBarBottomPx = WindowInsets.navigationBars.getBottom(density)
   val bottomPadding =
     with(density) {
       when {
         // Tracks the IME inset frame by frame as the keyboard animates in, so the bar travels up
-        // with the keys. Reserving the stored height instead would park it at the final position
-        // before the keyboard has even started to appear. At rest it lands exactly on the bar it
-        // replaces, so the overlay opens without the bar hopping.
+        // with the keys. At rest it lands exactly on the bar it replaces, so the overlay opens
+        // without the bar hopping.
         riseWithKeyboard ->
           kotlin.math
             .max(imeHeightPx, navigationBarBottomPx - BROWSER_CHROME_BAR_OFFSET.roundToPx())
@@ -958,10 +968,7 @@ fun SearchScreen(
         // Follows the IME down frame by frame while a tab opens, so the bar rides the keyboard
         // out instead of dropping once it has gone.
         openingTab -> imeHeightPx.toDp()
-        // Parked, not live: following the inset made the bar ride the IME up, then down, then
-        // up again whenever input restarted (a dummy editor, a focus handoff). The keys fill
-        // space the bar already holds.
-        else -> reservedKeyboardHeightPx.toDp()
+        else -> kotlin.math.max(imeHeightPx, navigationBarBottomPx).toDp()
       }
     }
 

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -1,0 +1,97 @@
+package com.searchlauncher.app.ui
+
+import android.app.Activity
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ImeTest {
+
+  @Test
+  fun softInputMode_isAlwaysVisibleWithoutResizing() {
+    val state = Ime.SOFT_INPUT_MODE and WindowManager.LayoutParams.SOFT_INPUT_MASK_STATE
+    val adjust = Ime.SOFT_INPUT_MODE and WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST
+    assertEquals(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE, state)
+    assertEquals(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING, adjust)
+  }
+
+  @Test
+  fun applyWindowMode_setsBothBitsTogether() {
+    val activity = activity()
+    Ime.applyWindowMode(activity.window)
+    val mode = activity.window.attributes.softInputMode
+    assertEquals(
+      WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE,
+      mode and WindowManager.LayoutParams.SOFT_INPUT_MASK_STATE,
+    )
+    assertEquals(
+      WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING,
+      mode and WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST,
+    )
+  }
+
+  @Test
+  fun warmup_isAFocusedZeroSizeEditorUntilReleased() {
+    val activity = activity()
+    Ime.installWarmup(activity)
+    val warmup = Ime.warmupFor(activity)
+    assertNotNull(warmup)
+    val editor = warmup!!
+    assertTrue(editor.isFocused)
+    assertTrue(editor.isFocusableInTouchMode)
+    assertEquals(0, editor.layoutParams.width)
+    assertEquals(0, editor.layoutParams.height)
+    assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, editor.importantForAccessibility)
+    assertTrue(editor.inputType and EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS != 0)
+    assertTrue(editor.parent is ViewGroup)
+
+    Ime.releaseWarmup(activity)
+    assertNull(Ime.warmupFor(activity))
+    assertNull(editor.parent)
+    assertFalse(editor.isFocusable)
+  }
+
+  @Test
+  fun installWarmup_isIdempotent() {
+    val activity = activity()
+    Ime.installWarmup(activity)
+    val first = Ime.warmupFor(activity)
+    Ime.installWarmup(activity)
+    assertSame(first, Ime.warmupFor(activity))
+    Ime.releaseWarmup(activity)
+  }
+
+  @Test
+  fun onWindowFocused_refocusesWarmupThenShowDoesNotThrow() {
+    val activity = activity()
+    Ime.installWarmup(activity)
+    val warmup = Ime.warmupFor(activity)!!
+    warmup.clearFocus()
+    Ime.onWindowFocused(activity)
+    assertTrue(warmup.isFocused)
+    Ime.show(activity.window.decorView)
+    Ime.hide(activity.window.decorView)
+    Ime.releaseWarmup(activity)
+  }
+
+  @Test
+  fun releaseWarmup_withoutInstall_isANoOp() {
+    Ime.releaseWarmup(activity())
+  }
+
+  private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -3,6 +3,7 @@ package com.searchlauncher.app.ui
 import android.app.Activity
 import android.view.WindowManager
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -62,6 +63,12 @@ class ImeTest {
     Ime.onWindowFocused(activity)
     Ime.show(activity.window.decorView)
     Ime.hide(activity.window.decorView)
+  }
+
+  @Test
+  fun show_returnsFalseWhenTheWindowIsNotFocused() {
+    val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+    assertFalse(Ime.show(activity.window.decorView))
   }
 
   private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).setup().get()

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -39,6 +39,7 @@ class ImeTest {
   @Test
   fun reservedHeight_usesStoredWhenPlausible() {
     assertEquals(800, Ime.reservedHeightPx(storedPx = 800, containerHeightPx = 2400))
+    assertEquals(901, Ime.reservedHeightPx(storedPx = 901, containerHeightPx = 2400))
   }
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -58,6 +58,21 @@ class ImeTest {
   }
 
   @Test
+  fun insetForLayout_usesLiveWhenPlausible() {
+    assertEquals(800, Ime.insetForLayoutPx(imePx = 800, storedPx = 900, containerHeightPx = 2400))
+    assertEquals(0, Ime.insetForLayoutPx(imePx = 0, storedPx = 900, containerHeightPx = 2400))
+  }
+
+  @Test
+  fun insetForLayout_ignoresFullScreenImeWindow() {
+    val reserved = Ime.reservedHeightPx(storedPx = 900, containerHeightPx = 2400)
+    assertEquals(
+      reserved,
+      Ime.insetForLayoutPx(imePx = 2300, storedPx = 900, containerHeightPx = 2400),
+    )
+  }
+
+  @Test
   fun showAndHide_doNotThrow() {
     val activity = activity()
     Ime.onWindowFocused(activity)

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -1,16 +1,8 @@
 package com.searchlauncher.app.ui
 
 import android.app.Activity
-import android.view.View
-import android.view.ViewGroup
 import android.view.WindowManager
-import android.view.inputmethod.EditorInfo
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -45,52 +37,30 @@ class ImeTest {
   }
 
   @Test
-  fun warmup_isAFocusedZeroSizeEditorUntilReleased() {
-    val activity = activity()
-    Ime.installWarmup(activity)
-    val warmup = Ime.warmupFor(activity)
-    assertNotNull(warmup)
-    val editor = warmup!!
-    assertTrue(editor.isFocused)
-    assertTrue(editor.isFocusableInTouchMode)
-    assertEquals(0, editor.layoutParams.width)
-    assertEquals(0, editor.layoutParams.height)
-    assertEquals(View.IMPORTANT_FOR_ACCESSIBILITY_NO, editor.importantForAccessibility)
-    assertTrue(editor.inputType and EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS != 0)
-    assertTrue(editor.parent is ViewGroup)
-
-    Ime.releaseWarmup(activity)
-    assertNull(Ime.warmupFor(activity))
-    assertNull(editor.parent)
-    assertFalse(editor.isFocusable)
+  fun reservedHeight_usesStoredWhenPlausible() {
+    assertEquals(800, Ime.reservedHeightPx(storedPx = 800, containerHeightPx = 2400))
   }
 
   @Test
-  fun installWarmup_isIdempotent() {
-    val activity = activity()
-    Ime.installWarmup(activity)
-    val first = Ime.warmupFor(activity)
-    Ime.installWarmup(activity)
-    assertSame(first, Ime.warmupFor(activity))
-    Ime.releaseWarmup(activity)
+  fun reservedHeight_guessesWhenStoredIsMissingOrHuge() {
+    val guessed = (2400 * Ime.DEFAULT_HEIGHT_FRACTION).toInt()
+    assertEquals(guessed, Ime.reservedHeightPx(storedPx = 0, containerHeightPx = 2400))
+    assertEquals(guessed, Ime.reservedHeightPx(storedPx = 50, containerHeightPx = 2400))
+    assertEquals(guessed, Ime.reservedHeightPx(storedPx = 2000, containerHeightPx = 2400))
   }
 
   @Test
-  fun onWindowFocused_refocusesWarmupThenShowDoesNotThrow() {
+  fun reservedHeight_keepsStoredWhileContainerSizeIsUnknown() {
+    assertEquals(800, Ime.reservedHeightPx(storedPx = 800, containerHeightPx = 0))
+    assertEquals(0, Ime.reservedHeightPx(storedPx = 0, containerHeightPx = 0))
+  }
+
+  @Test
+  fun showAndHide_doNotThrow() {
     val activity = activity()
-    Ime.installWarmup(activity)
-    val warmup = Ime.warmupFor(activity)!!
-    warmup.clearFocus()
     Ime.onWindowFocused(activity)
-    assertTrue(warmup.isFocused)
     Ime.show(activity.window.decorView)
     Ime.hide(activity.window.decorView)
-    Ime.releaseWarmup(activity)
-  }
-
-  @Test
-  fun releaseWarmup_withoutInstall_isANoOp() {
-    Ime.releaseWarmup(activity())
   }
 
   private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).setup().get()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The previous walkthrough parked the search bar above an empty keyboard well and kept re-asking the IME, which made the keys late and the bar jump.

This pass:
- Follows the live IME inset so the bar and keys travel together, instead of reserving a blank slot.
- Stops hiding the keyboard in `onPause` (that cold-started LatinIME on every trip to Settings). Without `SHOW_FORCED`, the IME still leaves with this window.
- Asks `showSoftInput` at most twice once the window is focused. Repeating it (and `WindowInsetsController.show`) restarted the appearance animation.
- Ignores full-screen IME inset readings so the bar cannot be pushed off the top.
- Keeps the wallpaper at the stored keyboard height so the picture does not crop or slide as the keys come up. Only the search bar rides the IME.

Wallpaper stays cropped whether the keyboard is down or up:

[Wallpaper crop with keyboard hidden](https://cursor.com/agents/bc-048b9d95-ea0e-419a-aef7-afecf74fe719/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwallpaper_crop_keyboard_hidden.png)
[Same wallpaper crop with keyboard shown](https://cursor.com/agents/bc-048b9d95-ea0e-419a-aef7-afecf74fe719/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwallpaper_crop_keyboard_shown.png)

## Testing
- `./gradlew testDebugUnitTest` and `./gradlew spotlessCheck`
- Emulator: Home from Settings — bar stays on screen, keyboard fills under it, wallpaper does not resize


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-048b9d95-ea0e-419a-aef7-afecf74fe719?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-048b9d95-ea0e-419a-aef7-afecf74fe719&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

