### PR TITLE
Multi-row favorites bar

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
@@ -23,6 +23,12 @@ object PreferencesKeys {
   val BROWSER_SHOW_FAVORITES = booleanPreferencesKey("browser_show_favorites")
   val HISTORY_LIMIT = intPreferencesKey("history_limit")
   val MIN_ICON_SIZE = intPreferencesKey("min_icon_size")
+  /**
+   * How many rows the favorites bar may wrap onto. `-1` is Auto (grow as needed, up to four);
+   * `1`–`4` cap growth at that many rows. See
+   * [com.searchlauncher.app.ui.components.FAVORITES_MAX_ROWS_AUTO].
+   */
+  val FAVORITES_MAX_ROWS = intPreferencesKey("favorites_max_rows")
   val AUTO_THEME_FROM_WALLPAPER = booleanPreferencesKey("auto_theme_from_wallpaper")
   val THEMED_ICONS = booleanPreferencesKey("themed_icons")
   val SEARCH_SHORTCUTS_ENABLED = booleanPreferencesKey("search_shortcuts_enabled")

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -90,6 +90,7 @@ import com.searchlauncher.app.ui.browser.indexOfTabShowing
 import com.searchlauncher.app.ui.browser.rememberBrowserTabSwipeState
 import com.searchlauncher.app.ui.components.BookmarkDialog
 import com.searchlauncher.app.ui.components.ConsentDialog
+import com.searchlauncher.app.ui.components.FAVORITES_MAX_ROWS_AUTO
 import com.searchlauncher.app.ui.components.FavoritesRow
 import com.searchlauncher.app.ui.components.PrivacyPolicyDialog
 import com.searchlauncher.app.ui.components.ResultMenuActions
@@ -209,6 +210,13 @@ fun SearchScreen(
       .collectAsState(initial = false)
   val minIconSizeSetting by
     remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
+  val favoritesMaxRows by
+    remember {
+        context.dataStore.data.map {
+          it[PreferencesKeys.FAVORITES_MAX_ROWS] ?: FAVORITES_MAX_ROWS_AUTO
+        }
+      }
+      .collectAsState(initial = FAVORITES_MAX_ROWS_AUTO)
   val autocorrectEnabled by
     remember { context.dataStore.data.map { it[PreferencesKeys.SEARCH_AUTOCORRECT] ?: false } }
       .collectAsState(initial = false)
@@ -1664,6 +1672,7 @@ fun SearchScreen(
                   favorites = searchOptionFavorites,
                   history = searchOptionExtras,
                   minIconSizeSetting = minIconSizeSetting,
+                  maxRows = favoritesMaxRows,
                   expandToFill = true,
                   reverseHistory = false,
                   drawDivider = false,
@@ -1713,6 +1722,7 @@ fun SearchScreen(
                   history = historyItems,
                   historyLimit = historyLimit,
                   minIconSizeSetting = minIconSizeSetting,
+                  maxRows = favoritesMaxRows,
                   onLaunch = { result ->
                     if (result is SearchResult.SearchIntent) {
                       searchRepository.reportUsageAsync(result.namespace, result.id)

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -85,6 +85,7 @@ import com.searchlauncher.app.R
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.DownloadIndexer
 import com.searchlauncher.app.ui.browser.AdBlocker
+import com.searchlauncher.app.ui.components.FAVORITES_MAX_ROWS_AUTO
 import com.searchlauncher.app.ui.components.PrivacyPolicyDialog
 import com.searchlauncher.app.ui.components.loadPrivacyPolicyText
 import com.searchlauncher.app.util.CustomActionHandler
@@ -165,7 +166,7 @@ fun SettingsScreen(
           modifier = Modifier.padding(16.dp),
           verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-          Text(text = "History", style = MaterialTheme.typography.titleMedium)
+          Text(text = "Favorites bar", style = MaterialTheme.typography.titleMedium)
 
           val scope = rememberCoroutineScope()
 
@@ -173,7 +174,55 @@ fun SettingsScreen(
             remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
               .collectAsState(initial = -1)
 
+          val favoritesMaxRows =
+            remember {
+                context.dataStore.data.map {
+                  it[PreferencesKeys.FAVORITES_MAX_ROWS] ?: FAVORITES_MAX_ROWS_AUTO
+                }
+              }
+              .collectAsState(initial = FAVORITES_MAX_ROWS_AUTO)
+
           Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "Rows", style = MaterialTheme.typography.bodyMedium)
+            Text(
+              text = "Add another row when favorites no longer fit at the icon size below.",
+              style = MaterialTheme.typography.labelSmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            )
+
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              val rowModes =
+                listOf("Auto" to FAVORITES_MAX_ROWS_AUTO, "1" to 1, "2" to 2, "3" to 3, "4" to 4)
+              rowModes.forEach { (label, value) ->
+                val isSelected = favoritesMaxRows.value == value
+                if (isSelected) {
+                  Button(
+                    onClick = { /* Already selected */},
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp),
+                  ) {
+                    Text(label, style = MaterialTheme.typography.labelMedium)
+                  }
+                } else {
+                  OutlinedButton(
+                    onClick = {
+                      scope.launch {
+                        context.dataStore.edit { it[PreferencesKeys.FAVORITES_MAX_ROWS] = value }
+                      }
+                    },
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp),
+                  ) {
+                    Text(label, style = MaterialTheme.typography.labelMedium)
+                  }
+                }
+              }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
             Text(text = "Show App History Icons", style = MaterialTheme.typography.bodyMedium)
 
             Row(

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -185,7 +185,8 @@ fun SettingsScreen(
           Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(text = "Rows", style = MaterialTheme.typography.bodyMedium)
             Text(
-              text = "Add another row when favorites no longer fit at the icon size below.",
+              text =
+                "Add another row when favorites no longer fit. Recents fill leftover spots on the last row.",
               style = MaterialTheme.typography.labelSmall,
               color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             )

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -124,6 +124,7 @@ import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.ResultLauncher
 import com.searchlauncher.app.ui.SearchActivity
 import com.searchlauncher.app.ui.components.BookmarkDialog
+import com.searchlauncher.app.ui.components.FAVORITES_MAX_ROWS_AUTO
 import com.searchlauncher.app.ui.components.FavoritesRow
 import com.searchlauncher.app.ui.components.SearchChromeBar
 import com.searchlauncher.app.ui.dataStore
@@ -535,6 +536,13 @@ internal fun BrowserScreen(
       .collectAsState(initial = -1)
   val minIconSizeSetting by
     remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
+  val favoritesMaxRows by
+    remember {
+        context.dataStore.data.map {
+          it[PreferencesKeys.FAVORITES_MAX_ROWS] ?: FAVORITES_MAX_ROWS_AUTO
+        }
+      }
+      .collectAsState(initial = FAVORITES_MAX_ROWS_AUTO)
   val historyItems =
     remember(allRecentItems, favoriteIds, historyLimit, privateMode) {
       if (privateMode || historyLimit == 0) emptyList()
@@ -1998,6 +2006,7 @@ internal fun BrowserScreen(
           historyItems = historyItems,
           historyLimit = historyLimit,
           minIconSizeSetting = minIconSizeSetting,
+          maxRows = favoritesMaxRows,
           showFavorites = showFavorites,
           barColor = chromeBarColor,
           barContentColor = chromeBarContentColor,
@@ -2276,6 +2285,7 @@ private fun BrowserLauncherChrome(
   historyItems: List<SearchResult>,
   historyLimit: Int,
   minIconSizeSetting: Int,
+  maxRows: Int,
   showFavorites: Boolean,
   barColor: Color,
   barContentColor: Color,
@@ -2368,6 +2378,7 @@ private fun BrowserLauncherChrome(
           history = historyItems,
           historyLimit = historyLimit,
           minIconSizeSetting = minIconSizeSetting,
+          maxRows = maxRows,
           onLaunch = onLaunchFavorite,
           onToggleFavorite = onToggleFavorite,
           onReorder = onReorder,

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -1,0 +1,219 @@
+package com.searchlauncher.app.ui.components
+
+/**
+ * How many rows the favorites bar may grow to.
+ *
+ * `-1` means Auto: add a row when pinned favorites no longer fit at the preferred icon size, up to
+ * [FAVORITES_MAX_ROWS_CAP]. `1`–`4` cap growth at that many rows; overflowing items shrink to fit,
+ * which is the original single-row behaviour when the cap is 1.
+ */
+const val FAVORITES_MAX_ROWS_AUTO = -1
+const val FAVORITES_MAX_ROWS_CAP = 4
+
+/** Grid + icon metrics for one measurement of the favorites bar. */
+internal data class FavoritesBarLayout(
+  val rowCount: Int,
+  val itemsPerRow: Int,
+  val iconSizePx: Float,
+  val historyCapacity: Int,
+  val showDivider: Boolean,
+  /** Pinned items sitting on the last row; the divider (if any) follows this many. */
+  val lastRowFavoriteCount: Int,
+)
+
+internal fun resolveFavoritesMaxRows(setting: Int): Int =
+  if (setting < 0) FAVORITES_MAX_ROWS_CAP else setting.coerceIn(1, FAVORITES_MAX_ROWS_CAP)
+
+/**
+ * How many icons fit in [totalWidthPx] at [iconSizePx], matching the original single-row formula
+ * (slightly generous via `+ spacing/2` so a near-fit still counts).
+ */
+internal fun itemsThatFit(
+  totalWidthPx: Float,
+  iconSizePx: Float,
+  spacingPx: Float,
+  reservedGapPx: Float = 0f,
+): Int {
+  val stride = iconSizePx + spacingPx
+  if (stride <= 0f) return 1
+  return ((totalWidthPx + spacingPx - reservedGapPx + (spacingPx / 2f)) / stride)
+    .toInt()
+    .coerceAtLeast(0)
+}
+
+internal fun ceilDiv(value: Int, divisor: Int): Int {
+  if (divisor <= 0) return value
+  if (value <= 0) return 0
+  return (value + divisor - 1) / divisor
+}
+
+/**
+ * Decide rows, grid width, icon size, and how many history items the last row can take.
+ *
+ * Rows grow for overflowing favorites first. History then fills leftover slots on the last row; a
+ * fixed history limit may shrink icons so that many items still fit in the chosen row count. Auto
+ * history never adds a row of its own.
+ */
+internal fun computeFavoritesBarLayout(
+  totalWidthPx: Float,
+  favoriteCount: Int,
+  historyLimit: Int,
+  minIconSizePx: Float,
+  spacingPx: Float,
+  dividerGapPx: Float,
+  drawDivider: Boolean,
+  expandToFill: Boolean,
+  maxRowsSetting: Int,
+): FavoritesBarLayout {
+  val maxRows = resolveFavoritesMaxRows(maxRowsSetting)
+  val preferredPerRow = itemsThatFit(totalWidthPx, minIconSizePx, spacingPx).coerceAtLeast(1)
+
+  val favRows =
+    if (favoriteCount <= 0) 0 else ceilDiv(favoriteCount, preferredPerRow).coerceAtLeast(1)
+  val rowCount =
+    when {
+      favoriteCount <= 0 -> 1
+      else -> favRows.coerceIn(1, maxRows)
+    }
+
+  var itemsPerRow =
+    if (favoriteCount > rowCount * preferredPerRow) {
+      ceilDiv(favoriteCount, rowCount).coerceAtLeast(1)
+    } else {
+      preferredPerRow
+    }
+
+  fun lastRowFavs(perRow: Int): Int {
+    if (favoriteCount <= 0) return 0
+    val fullRows = (rowCount - 1).coerceAtLeast(0)
+    return (favoriteCount - fullRows * perRow).coerceIn(1, perRow)
+  }
+
+  fun historySlots(perRow: Int, lastFavs: Int): Int {
+    if (historyLimit == 0) return 0
+    val gap = if (drawDivider && lastFavs > 0) dividerGapPx else 0f
+    val lastRowCap =
+      if (gap > 0f) {
+        // Capacity at the preferred size when we have not already shrunk past it; once perRow is
+        // larger than preferred, the grid itself is the limit (icons will shrink in phase 2).
+        if (perRow > preferredPerRow) perRow
+        else itemsThatFit(totalWidthPx, minIconSizePx, spacingPx, gap)
+      } else {
+        perRow
+      }
+    return (lastRowCap - lastFavs).coerceAtLeast(0)
+  }
+
+  var lastFavs = lastRowFavs(itemsPerRow)
+  var slots = historySlots(itemsPerRow, lastFavs)
+
+  val historyCapacity =
+    when {
+      historyLimit == 0 -> 0
+      historyLimit > 0 -> {
+        val wanted = historyLimit
+        if (wanted > slots) {
+          val totalWanted = favoriteCount + wanted
+          itemsPerRow = ceilDiv(totalWanted, rowCount).coerceAtLeast(1)
+          lastFavs = lastRowFavs(itemsPerRow)
+          slots = (itemsPerRow - lastFavs).coerceAtLeast(0)
+        }
+        wanted.coerceAtMost(slots)
+      }
+      else -> slots
+    }
+
+  val visibleTotal = favoriteCount + historyCapacity
+  val showDivider = drawDivider && favoriteCount > 0 && historyCapacity > 0
+  lastFavs = lastRowFavs(itemsPerRow)
+
+  val fullestRow = if (rowCount <= 1) visibleTotal.coerceAtLeast(1) else itemsPerRow
+  val gapForSize = if (rowCount <= 1 && showDivider) dividerGapPx else 0f
+  val iconSizePx =
+    computeIconSizePx(
+      totalWidthPx = totalWidthPx,
+      itemCount = fullestRow,
+      spacingPx = spacingPx,
+      reservedGapPx = gapForSize,
+      preferredIconSizePx = minIconSizePx,
+      expandToFill = expandToFill,
+    )
+
+  return FavoritesBarLayout(
+    rowCount = rowCount,
+    itemsPerRow = itemsPerRow,
+    iconSizePx = iconSizePx,
+    historyCapacity = historyCapacity,
+    showDivider = showDivider,
+    lastRowFavoriteCount = if (rowCount <= 1) favoriteCount else lastFavs,
+  )
+}
+
+internal fun computeIconSizePx(
+  totalWidthPx: Float,
+  itemCount: Int,
+  spacingPx: Float,
+  reservedGapPx: Float,
+  preferredIconSizePx: Float,
+  expandToFill: Boolean,
+): Float {
+  if (itemCount <= 0) return preferredIconSizePx.coerceAtLeast(1f)
+  val reserved = spacingPx * (itemCount - 1) + reservedGapPx
+  val calculated = (totalWidthPx - reserved) / itemCount
+  return when {
+    calculated <= 0f -> 1f
+    expandToFill -> calculated
+    else -> minOf(preferredIconSizePx, calculated)
+  }
+}
+
+internal fun itemRow(index: Int, itemsPerRow: Int): Int =
+  if (itemsPerRow <= 0) 0 else index / itemsPerRow
+
+internal fun itemCol(index: Int, itemsPerRow: Int): Int =
+  if (itemsPerRow <= 0) index else index % itemsPerRow
+
+internal fun rowItemCount(row: Int, totalCount: Int, itemsPerRow: Int): Int {
+  if (itemsPerRow <= 0) return totalCount
+  val start = row * itemsPerRow
+  return (totalCount - start).coerceIn(0, itemsPerRow)
+}
+
+/**
+ * Left edge of [index] within the bar, including per-row centering and the last-row divider gap.
+ */
+internal fun itemX(
+  index: Int,
+  totalCount: Int,
+  itemsPerRow: Int,
+  iconSizePx: Float,
+  spacingPx: Float,
+  totalWidthPx: Float,
+  showDivider: Boolean,
+  lastRowFavoriteCount: Int,
+  dividerGapPx: Float,
+  rowCount: Int,
+): Float {
+  val row = itemRow(index, itemsPerRow)
+  val col = itemCol(index, itemsPerRow)
+  val countInRow = rowItemCount(row, totalCount, itemsPerRow)
+  val lastRow = (rowCount - 1).coerceAtLeast(0)
+  val dividerInRow =
+    showDivider && row == lastRow && lastRowFavoriteCount > 0 && countInRow > lastRowFavoriteCount
+  val gap = if (dividerInRow) dividerGapPx else 0f
+  val contentWidth = countInRow * iconSizePx + (countInRow - 1).coerceAtLeast(0) * spacingPx + gap
+  val startX = (totalWidthPx - contentWidth) / 2f
+  var x = startX + col * (iconSizePx + spacingPx)
+  if (dividerInRow && col >= lastRowFavoriteCount) x += dividerGapPx
+  return x
+}
+
+internal fun itemY(index: Int, itemsPerRow: Int, iconSizePx: Float, rowSpacingPx: Float): Float {
+  val row = itemRow(index, itemsPerRow)
+  return row * (iconSizePx + rowSpacingPx)
+}
+
+internal fun barHeightPx(rowCount: Int, iconSizePx: Float, rowSpacingPx: Float): Float {
+  if (rowCount <= 0) return 0f
+  return rowCount * iconSizePx + (rowCount - 1) * rowSpacingPx
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -91,11 +91,13 @@ internal fun computeFavoritesBarLayout(
 
   fun historySlots(perRow: Int, lastFavs: Int): Int {
     if (historyLimit == 0) return 0
+    // A multi-row bar is a grid: leftover cells on the last row fill with recents. The divider
+    // sits in existing spacing so it does not steal a slot. A single row still reserves the
+    // original gap, matching the old dock.
+    if (rowCount > 1) return (perRow - lastFavs).coerceAtLeast(0)
     val gap = if (drawDivider && lastFavs > 0) dividerGapPx else 0f
     val lastRowCap =
       if (gap > 0f) {
-        // Capacity at the preferred size when we have not already shrunk past it; once perRow is
-        // larger than preferred, the grid itself is the limit (icons will shrink in phase 2).
         if (perRow > preferredPerRow) perRow
         else itemsThatFit(totalWidthPx, minIconSizePx, spacingPx, gap)
       } else {
@@ -180,7 +182,10 @@ internal fun rowItemCount(row: Int, totalCount: Int, itemsPerRow: Int): Int {
 }
 
 /**
- * Left edge of [index] within the bar, including per-row centering and the last-row divider gap.
+ * Left edge of [index] within the bar.
+ *
+ * A single row stays centered as a group, with the original divider gap. Multiple rows share one
+ * column grid so a short last row lines up under the first instead of floating in the middle.
  */
 internal fun itemX(
   index: Int,
@@ -196,8 +201,13 @@ internal fun itemX(
 ): Float {
   val row = itemRow(index, itemsPerRow)
   val col = itemCol(index, itemsPerRow)
-  val countInRow = rowItemCount(row, totalCount, itemsPerRow)
   val lastRow = (rowCount - 1).coerceAtLeast(0)
+  if (rowCount > 1) {
+    val gridWidth = itemsPerRow * iconSizePx + (itemsPerRow - 1).coerceAtLeast(0) * spacingPx
+    val startX = (totalWidthPx - gridWidth) / 2f
+    return startX + col * (iconSizePx + spacingPx)
+  }
+  val countInRow = rowItemCount(row, totalCount, itemsPerRow)
   val dividerInRow =
     showDivider && row == lastRow && lastRowFavoriteCount > 0 && countInRow > lastRowFavoriteCount
   val gap = if (dividerInRow) dividerGapPx else 0f

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -239,7 +239,10 @@ fun FavoritesRow(
     Box(modifier = Modifier.fillMaxWidth().height(barHeight)) {
       if (effectiveShowDivider && effectiveLastRowFavs > 0) {
         val dividerIndex = effectiveBoundary.coerceIn(0, (totalCount - 1).coerceAtLeast(0))
-        val dividerX = xForIndex(dividerIndex) - (dividerGapPx / 2) - (spacingPx / 2)
+        // Multi-row: the divider sits in the grid spacing. Single-row: the original reserved gap.
+        val dividerX =
+          if (rowCount > 1) xForIndex(dividerIndex) - (spacingPx / 2)
+          else xForIndex(dividerIndex) - (dividerGapPx / 2) - (spacingPx / 2)
         val dividerY = yForIndex((rowCount - 1) * itemsPerRow)
         Box(
           modifier =

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -6,10 +6,27 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,6 +36,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -31,7 +49,7 @@ import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.ThemedIcons
 import com.searchlauncher.app.ui.dataStore
 import com.searchlauncher.app.ui.toImageBitmap
-import kotlin.math.abs
+import kotlin.math.hypot
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
@@ -63,6 +81,11 @@ fun FavoritesRow(
    * menus identical. Left out, an item offers only what this row can do by itself.
    */
   menuActions: ((SearchResult) -> ResultMenuActions)? = null,
+  /**
+   * How many rows pinned favorites may wrap onto. [FAVORITES_MAX_ROWS_AUTO] grows as needed (up to
+   * [FAVORITES_MAX_ROWS_CAP]); `1`–`4` cap growth at that many rows.
+   */
+  maxRows: Int = FAVORITES_MAX_ROWS_AUTO,
 ) {
   if (favorites.isEmpty() && history.isEmpty()) return
 
@@ -71,56 +94,67 @@ fun FavoritesRow(
 
   val minIconSizeDp = minIconSizeSetting.dp
   val dividerGapDp = 16.dp
+  val minSpacingDp = 6.dp
+  val rowSpacingDp = 4.dp
 
   BoxWithConstraints(
     modifier =
       Modifier.fillMaxWidth().wrapContentHeight().padding(horizontal = 16.dp, vertical = 2.dp),
     contentAlignment = Alignment.Center,
   ) {
-    val minSpacingDp = 6.dp
     val spacingPx = with(density) { minSpacingDp.toPx() }
     val minIconSizePx = with(density) { minIconSizeDp.toPx() }
     val dividerGapPx = with(density) { dividerGapDp.toPx() }
+    val rowSpacingPx = with(density) { rowSpacingDp.toPx() }
     val totalWidthPx = constraints.maxWidth.toFloat()
 
-    // Dynamically calculate how many history items we can actually fit
+    val measured =
+      remember(
+        favorites.size,
+        history.size,
+        historyLimit,
+        totalWidthPx,
+        minIconSizeSetting,
+        drawDivider,
+        expandToFill,
+        maxRows,
+      ) {
+        computeFavoritesBarLayout(
+            totalWidthPx = totalWidthPx,
+            favoriteCount = favorites.size,
+            historyLimit = historyLimit,
+            minIconSizePx = minIconSizePx,
+            spacingPx = spacingPx,
+            dividerGapPx = dividerGapPx,
+            drawDivider = drawDivider,
+            expandToFill = expandToFill,
+            maxRowsSetting = maxRows,
+          )
+          .also { onCapacityChanged(it.historyCapacity) }
+      }
+
     val visibleHistory =
-      remember(favorites, history, totalWidthPx, historyLimit, minIconSizeSetting, drawDivider) {
-        val effectiveLimit =
-          if (historyLimit >= 0) {
-            historyLimit
-          } else {
-            val showDividerInitial = drawDivider && favorites.isNotEmpty() && history.isNotEmpty()
-            val gapToReserve = if (showDividerInitial) dividerGapPx else 0f
-
-            // Calculate max items that fit at min size
-            // Use +0.5 to be slightly more generous (floor vs round) to avoid 'too few' icons
-            val maxTotalItems =
-              ((totalWidthPx + spacingPx - gapToReserve + (spacingPx / 2f)) /
-                  (minIconSizePx + spacingPx))
-                .toInt()
-            (maxTotalItems - favorites.size).coerceAtLeast(0)
-          }
-
-        onCapacityChanged(effectiveLimit)
-        val visible = history.take(effectiveLimit)
+      remember(history, measured.historyCapacity, reverseHistory) {
+        val visible = history.take(measured.historyCapacity)
         if (reverseHistory) visible.reversed() else visible
       }
 
     val allItems = favorites + visibleHistory
     val boundaryIndex = favorites.size
-    val showDivider = drawDivider && favorites.isNotEmpty() && visibleHistory.isNotEmpty()
+    val showDivider = measured.showDivider
 
     // State for dragging
     var draggedItemId by remember { mutableStateOf<String?>(null) }
     var dragPosition by remember { mutableStateOf(Offset.Zero) }
-    var totalDragX by remember { mutableStateOf(0f) }
+    var totalDrag by remember { mutableStateOf(0f) }
     var currentOrder by remember(allItems) { mutableStateOf(allItems.map { it.favoriteKey }) }
     var showMenuForIndex by remember { mutableStateOf<Int?>(null) }
     var dragBoundaryIndex by remember(boundaryIndex) { mutableStateOf(boundaryIndex) }
     var initialDragIndex by remember { mutableStateOf(-1) }
 
     val totalCount = allItems.size
+    val itemsPerRow = measured.itemsPerRow
+    val rowCount = measured.rowCount
 
     // Update dragBoundaryIndex whenever order changes during drag
     LaunchedEffect(draggedItemId, currentOrder) {
@@ -170,26 +204,10 @@ fun FavoritesRow(
       }
     val iconBitmaps = themedIconBitmaps ?: plainIconBitmaps
 
-    // Calculate layout metrics
-    // We reserve space for the divider gap if needed
-    val effectiveSpacingCount = totalCount - 1
-    val baseReservedSpace =
-      (spacingPx * effectiveSpacingCount) + (if (showDivider) dividerGapPx else 0f)
-
-    val calculatedSizePx =
-      if (totalCount > 0) (totalWidthPx - baseReservedSpace) / totalCount else 0f
-    val preferredIconSizePx = with(density) { minIconSizeSetting.dp.toPx() }
-    val finalIconSizePx =
-      when {
-        calculatedSizePx <= 0f -> 1f
-        expandToFill -> calculatedSizePx
-        else -> minOf(preferredIconSizePx, calculatedSizePx)
-      }
+    val finalIconSizePx = measured.iconSizePx
     val finalIconSize = with(density) { finalIconSizePx.toDp() }
-
-    val itemWidthPx = finalIconSizePx + spacingPx
-    val contentWidthPx = (totalCount * finalIconSizePx) + baseReservedSpace - spacingPx
-    val startX = (totalWidthPx - contentWidthPx) / 2
+    val barHeightPx = barHeightPx(rowCount, finalIconSizePx, rowSpacingPx)
+    val barHeight = with(density) { barHeightPx.toDp() }
 
     val effectiveBoundary = if (draggedItemId != null) dragBoundaryIndex else boundaryIndex
     val effectiveShowDivider =
@@ -198,32 +216,38 @@ fun FavoritesRow(
       } else {
         showDivider
       }
+    val effectiveLastRowFavs =
+      if (rowCount <= 1) effectiveBoundary
+      else (effectiveBoundary - itemsPerRow * (rowCount - 1)).coerceIn(0, itemsPerRow)
 
-    // Helper to calculate relative X (without startX) for an item at a specific index
-    fun getRelativeXForIndex(index: Int): Float {
-      var x = index * (finalIconSizePx + spacingPx)
-      if (effectiveShowDivider && index >= effectiveBoundary) {
-        x += dividerGapPx
-      }
-      return x
-    }
+    fun xForIndex(index: Int): Float =
+      itemX(
+        index = index,
+        totalCount = totalCount,
+        itemsPerRow = itemsPerRow,
+        iconSizePx = finalIconSizePx,
+        spacingPx = spacingPx,
+        totalWidthPx = totalWidthPx,
+        showDivider = effectiveShowDivider,
+        lastRowFavoriteCount = effectiveLastRowFavs,
+        dividerGapPx = dividerGapPx,
+        rowCount = rowCount,
+      )
 
-    // Original helper for drag logic (includes startX)
-    fun getXPositionForIndex(index: Int): Float {
-      return startX + getRelativeXForIndex(index)
-    }
+    fun yForIndex(index: Int): Float = itemY(index, itemsPerRow, finalIconSizePx, rowSpacingPx)
 
-    Box(modifier = Modifier.fillMaxWidth().height(finalIconSize)) {
-      // Background Divider
-      if (effectiveShowDivider) {
-        val relativeDividerX =
-          getRelativeXForIndex(effectiveBoundary) - (dividerGapPx / 2) - (spacingPx / 2)
+    Box(modifier = Modifier.fillMaxWidth().height(barHeight)) {
+      if (effectiveShowDivider && effectiveLastRowFavs > 0) {
+        val dividerIndex = effectiveBoundary.coerceIn(0, (totalCount - 1).coerceAtLeast(0))
+        val dividerX = xForIndex(dividerIndex) - (dividerGapPx / 2) - (spacingPx / 2)
+        val dividerY = yForIndex((rowCount - 1) * itemsPerRow)
         Box(
           modifier =
-            Modifier.offset(x = with(density) { (startX + relativeDividerX).toDp() })
-              .width(1.5.dp)
-              .height(finalIconSize * 0.7f)
-              .align(Alignment.CenterStart)
+            Modifier.offset(
+                x = with(density) { dividerX.toDp() },
+                y = with(density) { (dividerY + finalIconSizePx * 0.15f).toDp() },
+              )
+              .size(width = 1.5.dp, height = finalIconSize * 0.7f)
               .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
         )
       }
@@ -237,50 +261,49 @@ fun FavoritesRow(
 
           // Use static position for the Box receiving gestures to avoid fighting the animation
           val displayIndex = if (isGhost) initialDragIndex else currentIndex
-          val relativeX = getRelativeXForIndex(displayIndex)
-          val relativeXDp = with(density) { relativeX.toDp() }
+          val xDp = with(density) { xForIndex(displayIndex).toDp() }
+          val yDp = with(density) { yForIndex(displayIndex).toDp() }
 
-          // Animate ONLY the relative position, not the startX group shift
-          val animatedRelativeXDp by
-            animateDpAsState(targetValue = relativeXDp, label = "ItemAnimation")
-          val startXDp = with(density) { startX.toDp() }
+          val animatedXDp by animateDpAsState(targetValue = xDp, label = "ItemAnimationX")
+          val animatedYDp by animateDpAsState(targetValue = yDp, label = "ItemAnimationY")
 
           Box(
             modifier =
-              Modifier.offset(x = startXDp + animatedRelativeXDp)
+              Modifier.offset(x = animatedXDp, y = animatedYDp)
                 .size(finalIconSize)
                 .clip(RoundedCornerShape(12.dp))
                 .graphicsLayer { alpha = if (isGhost) 0f else 1f }
                 .pointerInput(itemKey) { detectTapGestures(onTap = { onLaunch(result) }) }
-                .pointerInput(itemKey, startX, itemWidthPx) {
+                .pointerInput(itemKey, itemsPerRow, finalIconSizePx) {
                   detectDragGesturesAfterLongPress(
                     onDragStart = { offset ->
                       val freshIndex = currentOrder.indexOf(itemKey).takeIf { it != -1 } ?: 0
                       initialDragIndex = freshIndex
 
-                      // Calculate CURRENT visual position for smooth handoff
-                      val currentVisualXPx = startX + with(density) { animatedRelativeXDp.toPx() }
+                      val currentVisualXPx = with(density) { animatedXDp.toPx() }
+                      val currentVisualYPx = with(density) { animatedYDp.toPx() }
 
                       draggedItemId = itemKey
-                      dragPosition = Offset(currentVisualXPx + offset.x, offset.y)
-                      totalDragX = 0f
+                      dragPosition =
+                        Offset(currentVisualXPx + offset.x, currentVisualYPx + offset.y)
+                      totalDrag = 0f
                       haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     },
                     onDrag = { change, dragAmount ->
                       change.consume()
                       dragPosition += dragAmount
-                      totalDragX += abs(dragAmount.x)
+                      totalDrag += hypot(dragAmount.x, dragAmount.y)
 
                       val draggedId = draggedItemId ?: return@detectDragGesturesAfterLongPress
                       val dragIdx = currentOrder.indexOf(draggedId)
                       if (dragIdx == -1) return@detectDragGesturesAfterLongPress
 
-                      // Calculate target index by finding which item center it's closest to
                       var bestIndex = 0
                       var minDistance = Float.MAX_VALUE
                       for (i in 0 until totalCount) {
-                        val centerX = getXPositionForIndex(i) + finalIconSizePx / 2
-                        val dist = abs(dragPosition.x - centerX)
+                        val centerX = xForIndex(i) + finalIconSizePx / 2
+                        val centerY = yForIndex(i) + finalIconSizePx / 2
+                        val dist = hypot(dragPosition.x - centerX, dragPosition.y - centerY)
                         if (dist < minDistance) {
                           minDistance = dist
                           bestIndex = i
@@ -300,34 +323,29 @@ fun FavoritesRow(
                       val finalIdx = currentOrder.indexOf(draggedId)
                       val dragThreshold = with(density) { 10.dp.toPx() }
 
-                      if (finalIdx != -1 && totalDragX < dragThreshold) {
+                      if (finalIdx != -1 && totalDrag < dragThreshold) {
                         showMenuForIndex = finalIdx
                       } else {
-                        // REORDER / MOVE Logic
                         val wasFavorite = favorites.any { it.favoriteKey == draggedId }
                         val isNowInFavoriteZone = finalIdx < boundaryIndex
 
                         if (!wasFavorite && isNowInFavoriteZone) {
-                          // History item moved to favorites!
                           onToggleFavorite(result)
-                          // The SearchScreen will re-trigger a fetch and update currentOrder
                         } else if (wasFavorite && isNowInFavoriteZone) {
-                          // Just reordering within favorites
                           onReorder(currentOrder.take(boundaryIndex))
                         } else if (wasFavorite && !isNowInFavoriteZone) {
-                          // Favorite moved out - unfavorite it? (User didn't ask but it's natural)
                           onToggleFavorite(result)
                         }
                       }
 
                       draggedItemId = null
                       initialDragIndex = -1
-                      totalDragX = 0f
+                      totalDrag = 0f
                     },
                     onDragCancel = {
                       draggedItemId = null
                       initialDragIndex = -1
-                      totalDragX = 0f
+                      totalDrag = 0f
                     },
                   )
                 },
@@ -338,11 +356,10 @@ fun FavoritesRow(
               Image(
                 bitmap = imageBitmap,
                 contentDescription = result.title,
-                contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier.size(finalIconSize * 0.8f),
               )
             } else {
-              // Fallback placeholder for missing icons
               Box(
                 modifier =
                   Modifier.size(finalIconSize * 0.7f)
@@ -360,17 +377,13 @@ fun FavoritesRow(
               }
             }
 
-            // Context Menu
             DropdownMenu(
-              expanded = showMenuForIndex == currentIndex, // Use currentIndex for menu
+              expanded = showMenuForIndex == currentIndex,
               onDismissRequest = { showMenuForIndex = null },
               modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant),
               properties = PopupProperties(focusable = false),
             ) {
               val isFavorite = favorites.any { it.favoriteKey == result.favoriteKey }
-              // The favourite entry is the one thing that reads differently here — an item in this
-              // row is already a favourite, so it offers to remove rather than to add — and that
-              // comes out of isFavorite rather than out of a different menu.
               val actions =
                 menuActions?.invoke(result)
                   ?: ResultMenuActions(onToggleFavorite = { onToggleFavorite(result) })
@@ -387,13 +400,11 @@ fun FavoritesRow(
       }
     }
 
-    // 2. Drag Overlay
-    // Positioned using global coordinates derived from gesture
     draggedItemId?.let { id ->
       val result = allItems.find { it.favoriteKey == id } ?: return@let
       val imageBitmap = iconBitmaps[id] ?: return@let
 
-      Box(modifier = Modifier.fillMaxWidth().height(finalIconSize)) {
+      Box(modifier = Modifier.fillMaxWidth().height(barHeight)) {
         Box(
           modifier =
             Modifier.offset {
@@ -418,7 +429,7 @@ fun FavoritesRow(
           Image(
             bitmap = imageBitmap,
             contentDescription = result.title,
-            contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+            contentScale = ContentScale.Fit,
             modifier = Modifier.size(finalIconSize * 0.8f),
           )
         }

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -57,9 +57,17 @@ class FavoritesBarLayoutTest {
     assertEquals(2, result.rowCount)
     assertEquals(10, result.itemsPerRow)
     assertEquals(icon, result.iconSizePx, 0.01f)
-    // 20 slots − 14 favorites = 6 leftover on the last row (divider reduces that a little).
-    assertTrue(result.historyCapacity in 5..6)
+    // Last row keeps the leftover 4 favorites and fills the other 6 cells with recents.
+    assertEquals(6, result.historyCapacity)
     assertEquals(4, result.lastRowFavoriteCount)
+  }
+
+  @Test
+  fun `last row leftover cells are offered to recents`() {
+    val result = layout(favorites = 12)
+    assertEquals(2, result.rowCount)
+    assertEquals(2, result.lastRowFavoriteCount)
+    assertEquals(8, result.historyCapacity)
   }
 
   @Test
@@ -142,6 +150,39 @@ class FavoritesBarLayoutTest {
     assertEquals(0f, y0, 0.01f)
     assertEquals(36f, y1, 0.01f)
     assertEquals(68f, barHeightPx(2, iconSizePx = 32f, rowSpacingPx = 4f), 0.01f)
+  }
+
+  @Test
+  fun `a short last row lines up with the first column of the grid`() {
+    val firstColRow0 =
+      itemX(
+        index = 0,
+        totalCount = 12,
+        itemsPerRow = 10,
+        iconSizePx = 32f,
+        spacingPx = 6f,
+        totalWidthPx = width,
+        showDivider = true,
+        lastRowFavoriteCount = 2,
+        dividerGapPx = divider,
+        rowCount = 2,
+      )
+    val firstColRow1 =
+      itemX(
+        index = 10,
+        totalCount = 12,
+        itemsPerRow = 10,
+        iconSizePx = 32f,
+        spacingPx = 6f,
+        totalWidthPx = width,
+        showDivider = true,
+        lastRowFavoriteCount = 2,
+        dividerGapPx = divider,
+        rowCount = 2,
+      )
+    assertEquals(firstColRow0, firstColRow1, 0.01f)
+    // Must not be independently centered (that would sit near the middle of the bar).
+    assertTrue(firstColRow1 < width / 4f)
   }
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -1,0 +1,188 @@
+package com.searchlauncher.app.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FavoritesBarLayoutTest {
+
+  private val width = 380f
+  private val icon = 32f
+  private val spacing = 6f
+  private val divider = 16f
+
+  /** 380 + 6 + 3 = 389; 389 / 38 = 10.23 → 10 icons at the preferred size. */
+  private val tenFit = itemsThatFit(width, icon, spacing)
+
+  private fun layout(
+    favorites: Int,
+    historyLimit: Int = -1,
+    maxRows: Int = FAVORITES_MAX_ROWS_AUTO,
+    drawDivider: Boolean = true,
+    expandToFill: Boolean = false,
+  ) =
+    computeFavoritesBarLayout(
+      totalWidthPx = width,
+      favoriteCount = favorites,
+      historyLimit = historyLimit,
+      minIconSizePx = icon,
+      spacingPx = spacing,
+      dividerGapPx = divider,
+      drawDivider = drawDivider,
+      expandToFill = expandToFill,
+      maxRowsSetting = maxRows,
+    )
+
+  @Test
+  fun `itemsThatFit matches the original single-row formula`() {
+    assertEquals(10, tenFit)
+    assertEquals(9, itemsThatFit(width, icon, spacing, reservedGapPx = divider))
+  }
+
+  @Test
+  fun `favorites that fit stay on one row`() {
+    val result = layout(favorites = 4)
+    assertEquals(1, result.rowCount)
+    assertEquals(10, result.itemsPerRow)
+    assertEquals(icon, result.iconSizePx, 0.01f)
+    assertTrue(result.historyCapacity > 0)
+    assertTrue(result.showDivider)
+    assertEquals(4, result.lastRowFavoriteCount)
+  }
+
+  @Test
+  fun `overflowing favorites wrap onto a second row`() {
+    val result = layout(favorites = 14)
+    assertEquals(2, result.rowCount)
+    assertEquals(10, result.itemsPerRow)
+    assertEquals(icon, result.iconSizePx, 0.01f)
+    // 20 slots − 14 favorites = 6 leftover on the last row (divider reduces that a little).
+    assertTrue(result.historyCapacity in 5..6)
+    assertEquals(4, result.lastRowFavoriteCount)
+  }
+
+  @Test
+  fun `a one-row cap shrinks icons instead of wrapping`() {
+    val result = layout(favorites = 14, maxRows = 1, historyLimit = 0)
+    assertEquals(1, result.rowCount)
+    assertEquals(14, result.itemsPerRow)
+    assertTrue(result.iconSizePx < icon)
+    assertEquals(0, result.historyCapacity)
+    assertFalse(result.showDivider)
+  }
+
+  @Test
+  fun `auto history never adds a row of its own`() {
+    val few = layout(favorites = 3, historyLimit = -1)
+    assertEquals(1, few.rowCount)
+    val none = layout(favorites = 10, historyLimit = -1)
+    assertEquals(1, none.rowCount)
+    // Ten fill a row exactly; leftover history is zero (or one less if the divider is reserved).
+    assertEquals(0, none.historyCapacity)
+  }
+
+  @Test
+  fun `hiding history leaves leftover slots empty`() {
+    val result = layout(favorites = 4, historyLimit = 0)
+    assertEquals(0, result.historyCapacity)
+    assertFalse(result.showDivider)
+    assertEquals(1, result.rowCount)
+    assertEquals(icon, result.iconSizePx, 0.01f)
+  }
+
+  @Test
+  fun `fixed history shrinks a single row to fit`() {
+    val result = layout(favorites = 8, historyLimit = 8, maxRows = 1)
+    assertEquals(1, result.rowCount)
+    assertEquals(16, result.itemsPerRow)
+    assertEquals(8, result.historyCapacity)
+    assertTrue(result.iconSizePx < icon)
+  }
+
+  @Test
+  fun `history-only uses a single row`() {
+    val result = layout(favorites = 0, historyLimit = -1)
+    assertEquals(1, result.rowCount)
+    assertEquals(0, result.lastRowFavoriteCount)
+    assertFalse(result.showDivider)
+    assertEquals(tenFit, result.historyCapacity)
+  }
+
+  @Test
+  fun `auto grows up to the cap then shrinks`() {
+    val overflow = layout(favorites = 41, historyLimit = 0)
+    assertEquals(FAVORITES_MAX_ROWS_CAP, overflow.rowCount)
+    assertTrue(overflow.itemsPerRow > tenFit)
+    assertTrue(overflow.iconSizePx < icon)
+  }
+
+  @Test
+  fun `resolveFavoritesMaxRows treats negative as auto`() {
+    assertEquals(FAVORITES_MAX_ROWS_CAP, resolveFavoritesMaxRows(FAVORITES_MAX_ROWS_AUTO))
+    assertEquals(1, resolveFavoritesMaxRows(1))
+    assertEquals(FAVORITES_MAX_ROWS_CAP, resolveFavoritesMaxRows(99))
+    assertEquals(2, resolveFavoritesMaxRows(2))
+  }
+
+  @Test
+  fun `item cells are row-major`() {
+    assertEquals(0, itemRow(4, itemsPerRow = 6))
+    assertEquals(4, itemCol(4, itemsPerRow = 6))
+    assertEquals(1, itemRow(8, itemsPerRow = 6))
+    assertEquals(2, itemCol(8, itemsPerRow = 6))
+    assertEquals(6, rowItemCount(0, totalCount = 8, itemsPerRow = 6))
+    assertEquals(2, rowItemCount(1, totalCount = 8, itemsPerRow = 6))
+  }
+
+  @Test
+  fun `second-row items sit below the first`() {
+    val y0 = itemY(0, itemsPerRow = 6, iconSizePx = 32f, rowSpacingPx = 4f)
+    val y1 = itemY(6, itemsPerRow = 6, iconSizePx = 32f, rowSpacingPx = 4f)
+    assertEquals(0f, y0, 0.01f)
+    assertEquals(36f, y1, 0.01f)
+    assertEquals(68f, barHeightPx(2, iconSizePx = 32f, rowSpacingPx = 4f), 0.01f)
+  }
+
+  @Test
+  fun `last-row items are centered and skip the divider gap`() {
+    // One row, 4 favorites + 2 history, divider between them.
+    val x0 =
+      itemX(
+        index = 0,
+        totalCount = 6,
+        itemsPerRow = 10,
+        iconSizePx = 32f,
+        spacingPx = 6f,
+        totalWidthPx = width,
+        showDivider = true,
+        lastRowFavoriteCount = 4,
+        dividerGapPx = divider,
+        rowCount = 1,
+      )
+    val x4 =
+      itemX(
+        index = 4,
+        totalCount = 6,
+        itemsPerRow = 10,
+        iconSizePx = 32f,
+        spacingPx = 6f,
+        totalWidthPx = width,
+        showDivider = true,
+        lastRowFavoriteCount = 4,
+        dividerGapPx = divider,
+        rowCount = 1,
+      )
+    // Four icons + 3 gaps + divider + start of the 5th icon.
+    val contentWidth = 6 * 32f + 5 * 6f + divider
+    val start = (width - contentWidth) / 2f
+    assertEquals(start, x0, 0.01f)
+    assertEquals(start + 4 * (32f + 6f) + divider, x4, 0.01f)
+  }
+
+  @Test
+  fun `expandToFill grows icons on a short single row`() {
+    val result = layout(favorites = 3, historyLimit = 0, expandToFill = true)
+    assertTrue(result.iconSizePx > icon)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Favorites that no longer fit at the preferred icon size wrap onto extra rows instead of shrinking in a single row.

**Behavior**
- Auto (default): add a row when pinned favorites overflow, up to 4 rows
- 1 / 2 / 3 / 4: cap growth at that many rows (1 is the previous single-row layout)
- Recents fill leftover slots on the last row, aligned to the same grid as the first row
- Drag-to-reorder works across rows

**Settings**
The History card is now **Favorites bar** and includes a Rows control (Auto / 1 / 2 / 3 / 4).

**Testing**
- `./gradlew test spotlessCheck` passed
- Emulator: 12 favorites wrap to 2 rows on Auto; leftover last-row cells fill with recents and line up under the first row

[Two-row favorites bar](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavorites_bar_two_rows.png)
[Last row filled with recents](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavorites_last_row_recents.png)
[Favorites bar Rows setting](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_favorites_bar_rows.png)
[Single-row cap shrinks icons](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavorites_bar_one_row.png)
[favorites_bar_auto_wraps_to_two_rows.mp4](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavorites_bar_auto_wraps_to_two_rows.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

