### PR TITLE
Make a fixed favorites row count always use that many rows

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
+++ b/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
@@ -48,6 +48,9 @@ class SearchLauncherApp : Application() {
   val favoritesRepositoryOrNull: FavoritesRepository?
     get() = if (::favoritesRepository.isInitialized) favoritesRepository else null
 
+  val historyRepositoryOrNull: HistoryRepository?
+    get() = if (::historyRepository.isInitialized) historyRepository else null
+
   override fun onCreate() {
     super.onCreate()
     // The private browser gets an isolated WebView process/profile and must not initialize the

--- a/app/src/main/java/com/searchlauncher/app/data/HistoryRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/HistoryRepository.kt
@@ -5,13 +5,20 @@ import android.content.SharedPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.json.JSONArray
+import org.json.JSONObject
+
+data class HistoryEntry(val id: String, val lastUsedMs: Long)
 
 class HistoryRepository(context: Context) {
   private val prefs: SharedPreferences =
     context.getSharedPreferences(Prefs.History.FILE, Context.MODE_PRIVATE)
 
   private val _historyIds = MutableStateFlow<List<String>>(emptyList())
+  /** Ordered list of recently used ids, newest first. */
   val historyIds: StateFlow<List<String>> = _historyIds
+
+  private val _historyEntries = MutableStateFlow<List<HistoryEntry>>(emptyList())
+  val historyEntries: StateFlow<List<HistoryEntry>> = _historyEntries
 
   init {
     loadHistory()
@@ -19,42 +26,66 @@ class HistoryRepository(context: Context) {
 
   private fun loadHistory() {
     val jsonString = prefs.getString(Prefs.History.IDS, null)
-    if (jsonString != null) {
-      try {
-        val array = JSONArray(jsonString)
-        val list = mutableListOf<String>()
-        for (i in 0 until array.length()) {
-          list.add(array.getString(i))
-        }
-        _historyIds.value = list
-      } catch (e: Exception) {
-        e.printStackTrace()
+    if (jsonString == null) return
+    try {
+      val array = JSONArray(jsonString)
+      val times = loadTimes()
+      val now = System.currentTimeMillis()
+      val entries = mutableListOf<HistoryEntry>()
+      for (i in 0 until array.length()) {
+        val id = array.getString(i)
+        // Missing times keep list order: each older slot is one second earlier.
+        val at = times[id] ?: (now - i * 1000L)
+        entries.add(HistoryEntry(id, at))
       }
+      publish(entries)
+    } catch (e: Exception) {
+      e.printStackTrace()
+    }
+  }
+
+  private fun loadTimes(): Map<String, Long> {
+    val raw = prefs.getString(Prefs.History.TIMES, null) ?: return emptyMap()
+    return try {
+      val obj = JSONObject(raw)
+      buildMap { obj.keys().forEach { key -> put(key, obj.optLong(key, 0L)) } }
+    } catch (e: Exception) {
+      emptyMap()
     }
   }
 
   /** Records that an app was used. Moves it to the front of the list. */
-  fun addHistoryItem(id: String) {
-    val currentHistory = _historyIds.value.toMutableList()
-    // Remove if already exists so we can move it to front
-    currentHistory.remove(id)
-    currentHistory.add(0, id)
-
-    // Limit total history size
-    val truncatedHistory = currentHistory.take(20)
-
-    _historyIds.value = truncatedHistory
-    saveHistory(truncatedHistory)
+  fun addHistoryItem(id: String, atMs: Long = System.currentTimeMillis()) {
+    val current = _historyEntries.value.toMutableList()
+    current.removeAll { it.id == id }
+    current.add(0, HistoryEntry(id, atMs))
+    publish(current.take(20))
+    save()
   }
 
-  private fun saveHistory(history: List<String>) {
+  private fun publish(entries: List<HistoryEntry>) {
+    _historyEntries.value = entries
+    _historyIds.value = entries.map { it.id }
+  }
+
+  private fun save() {
     val array = JSONArray()
-    history.forEach { array.put(it) }
-    prefs.edit().putString(Prefs.History.IDS, array.toString()).apply()
+    val times = JSONObject()
+    _historyEntries.value.forEach { entry ->
+      array.put(entry.id)
+      times.put(entry.id, entry.lastUsedMs)
+    }
+    prefs
+      .edit()
+      .putString(Prefs.History.IDS, array.toString())
+      .putString(Prefs.History.TIMES, times.toString())
+      .apply()
   }
 
   fun clearHistory() {
-    _historyIds.value = emptyList()
-    prefs.edit().remove(Prefs.History.IDS).apply()
+    publish(emptyList())
+    prefs.edit().remove(Prefs.History.IDS).remove(Prefs.History.TIMES).apply()
   }
+
+  fun timesById(): Map<String, Long> = _historyEntries.value.associate { it.id to it.lastUsedMs }
 }

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -76,6 +76,8 @@ object Prefs {
   object History {
     const val FILE = "history"
     const val IDS = "history_ids"
+    /** Last-used millis keyed by the same ids as [IDS], so recents can mix with open tabs. */
+    const val TIMES = "history_times"
   }
 
   /** Last-used chat app per contact (keys are contact ids, so no fixed key names). */

--- a/app/src/main/java/com/searchlauncher/app/data/Recents.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Recents.kt
@@ -1,0 +1,34 @@
+package com.searchlauncher.app.data
+
+/**
+ * An item in the favorites-bar recents strip, with the time used to order it against the others.
+ */
+data class TimedRecent(val result: SearchResult, val atMs: Long)
+
+/**
+ * Apps and open tabs share one newest-first strip. [appTimes] is keyed by history id, result id, or
+ * favorite key — whichever the caller recorded.
+ */
+fun mergeRecentsByTime(
+  apps: List<SearchResult>,
+  appTimes: Map<String, Long>,
+  tabs: List<TimedRecent>,
+): List<TimedRecent> {
+  val timedApps =
+    apps.map { result ->
+      val atMs =
+        appTimes[result.id]
+          ?: appTimes[result.favoriteKey]
+          ?: appTimes[FavoriteKeys.normalize(result.id)]
+          ?: 0L
+      TimedRecent(result, atMs)
+    }
+  return (timedApps + tabs).sortedByDescending { it.atMs }
+}
+
+fun applyHistoryLimit(items: List<SearchResult>, historyLimit: Int): List<SearchResult> =
+  when {
+    historyLimit == 0 -> emptyList()
+    historyLimit > 0 -> items.take(historyLimit)
+    else -> items
+  }

--- a/app/src/main/java/com/searchlauncher/app/data/SearchOptions.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchOptions.kt
@@ -21,6 +21,34 @@ object SearchOptions {
   }
 
   /**
+   * Id usage stats are stored and read under. Indexed results use `search_google`; the query-time
+   * bar uses `google`; a typed alias hit uses `shortcut_g`. All three must count as the same
+   * shortcut or the bar never sees the usage the results list just recorded.
+   */
+  fun canonicalId(raw: String, aliasToId: (String) -> String? = { null }): String {
+    val id = normalizeId(raw)
+    if (id.startsWith("shortcut_")) {
+      val alias = id.removePrefix("shortcut_")
+      return aliasToId(alias) ?: id
+    }
+    return id
+  }
+
+  /** Same default tilt [SearchRepository.getSearchShortcuts] gives unused Google / Play Store. */
+  fun defaultUsageBoost(id: String): Int =
+    when (normalizeId(id)) {
+      "google" -> 2
+      "playstore" -> 1
+      else -> 0
+    }
+
+  /** Alternate ids that may already be stored for [raw] from older reportUsage call sites. */
+  fun usageIdAliases(raw: String, aliasToId: (String) -> String? = { null }): List<String> {
+    val canonical = canonicalId(raw, aliasToId)
+    return listOf(canonical, raw, normalizeId(raw), "search_$canonical").distinct()
+  }
+
+  /**
    * Splits [shortcuts] into pinned favorites (in [favoriteIds] order) and the remaining options
    * that fill unused slots in the bar.
    */
@@ -36,17 +64,34 @@ object SearchOptions {
   }
 
   /**
-   * Orders the fill slots by how often each option was used, most-used first, so an option migrates
-   * toward the divider as the user picks it. The sort is stable, so options nobody has used yet
-   * keep their incoming order instead of shuffling on every launch.
-   *
-   * Pinned favorites are deliberately not sorted this way: their order is the one the user set by
-   * dragging, and usage counts must not overrule it.
+   * Orders fill slots the same way results do: most-used first (Google / Play Store slightly ahead
+   * when unused), then the built-in catalog. Pinned favorites keep the drag order.
    */
   fun byUsage(
     shortcuts: List<SearchShortcut>,
     usageCount: (SearchShortcut) -> Int,
-  ): List<SearchShortcut> = shortcuts.sortedByDescending(usageCount)
+  ): List<SearchShortcut> {
+    val counts = shortcuts.associate { it.id to usageCount(it) }
+    return rankByUsage(shortcuts, { it.id }, { it.description }) { counts[it] ?: 0 }
+  }
+
+  /**
+   * The same order [com.searchlauncher.app.data.SearchRepository.getSearchShortcuts] appends onto
+   * the results list: most-used first (with the Google / Play Store tilt), then the built-in
+   * catalog order. The query-time favorites bar uses this so a tap that moves a shortcut in results
+   * also moves it in the bar.
+   */
+  fun <T> rankByUsage(
+    items: List<T>,
+    idOf: (T) -> String,
+    titleOf: (T) -> String,
+    usageCount: (String) -> Int,
+  ): List<T> =
+    items.sortedWith(
+      compareByDescending<T> { usageCount(idOf(it)) + defaultUsageBoost(idOf(it)) }
+        .thenBy { DefaultShortcuts.searchShortcutOrder(idOf(it)) }
+        .thenBy { titleOf(it) }
+    )
 
   /**
    * The term to send to a search option. An alias prefix (`y cats`) is stripped so tapping Google

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
@@ -190,14 +190,38 @@ object SearchRanker {
     usageStats: Map<String, Int>,
     namespace: String,
     id: String,
-  ): Int = usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
+  ): Int {
+    if (namespace != SearchOptions.NAMESPACE) {
+      return usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
+    }
+    for (alias in SearchOptions.usageIdAliases(id)) {
+      usageStats[usageKey(namespace, alias)]?.let {
+        return it
+      }
+      usageStats[alias]?.let {
+        return it
+      }
+    }
+    return 0
+  }
 
   private fun getQueryUsagePoints(
     queryUsageStats: Map<String, Int>,
     query: String?,
     namespace: String,
     id: String,
-  ): Int = query?.let { queryUsageStats[queryUsageKey(it, namespace, id)] } ?: 0
+  ): Int {
+    if (query == null) return 0
+    if (namespace != SearchOptions.NAMESPACE) {
+      return queryUsageStats[queryUsageKey(query, namespace, id)] ?: 0
+    }
+    for (alias in SearchOptions.usageIdAliases(id)) {
+      queryUsageStats[queryUsageKey(query, namespace, alias)]?.let {
+        return it
+      }
+    }
+    return 0
+  }
 
   private fun normalizedUsageQuery(query: String?): String? =
     query?.trim()?.lowercase()?.replace(Regex("\\s+"), " ")?.takeIf { it.isNotEmpty() }

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -18,6 +18,7 @@ import androidx.datastore.preferences.core.edit
 import com.google.common.util.concurrent.ListenableFuture
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.ui.PreferencesKeys
+import com.searchlauncher.app.ui.browser.toSearchResult
 import com.searchlauncher.app.ui.dataStore
 import com.searchlauncher.app.util.FuzzyMatch
 import com.searchlauncher.app.util.SystemUtils
@@ -1928,7 +1929,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private fun searchOpenTabs(query: String): List<SearchResult> {
     val tabs = com.searchlauncher.app.ui.browser.BrowserTabStore.tabs?.items ?: return emptyList()
     return tabs.mapNotNull { tab ->
-      if (tab.url.startsWith("about:")) return@mapNotNull null
+      val result = tab.toSearchResult(context) ?: return@mapNotNull null
       val address = tab.url.removePrefix("https://").removePrefix("http://").removeSuffix("/")
       val title = tab.title?.takeUnless(String::isBlank)
       // Either the page's name or its address can be what the user remembers it by.
@@ -1938,20 +1939,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           FuzzyMatch.calculateScore(query, address),
         )
       if (score < RankingScores.BROWSER_TAB_MIN_SCORE) return@mapNotNull null
-
-      SearchResult.BrowserTab(
-        id = "browser_tab_${tab.id}",
-        title = title ?: address,
-        // Says what the result is rather than repeating the address, which the title usually
-        // already conveys and which no other result type shows either.
-        subtitle = "Open tab",
-        icon =
-          tab.favicon?.let { BitmapDrawable(context.resources, it) }
-            ?: context.getDrawable(com.searchlauncher.app.R.drawable.ic_globe),
-        rankingScore = RankingScores.BROWSER_TAB_BASE + score,
-        tabId = tab.id,
-        url = tab.url,
-      )
+      result.copy(rankingScore = RankingScores.BROWSER_TAB_BASE + score)
     }
   }
 

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -1269,14 +1269,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             val app = context.applicationContext as? SearchLauncherApp
             val repoShortcuts = app?.searchShortcutRepository?.items?.value ?: emptyList()
             val sortedRepoShortcuts =
-              repoShortcuts.sortedWith(
-                compareByDescending<com.searchlauncher.app.data.SearchShortcut> { shortcut ->
-                    getGlobalUsageCount("search_shortcuts", shortcut.id) +
-                      getDefaultSearchShortcutBoost(shortcut.id)
-                  }
-                  .thenBy { shortcut -> DefaultShortcuts.searchShortcutOrder(shortcut.id) }
-                  .thenBy { shortcut -> shortcut.description }
-              )
+              SearchOptions.rankByUsage(repoShortcuts, { it.id }, { it.description }) { id ->
+                getGlobalUsageCount(SearchOptions.NAMESPACE, id)
+              }
             sortedRepoShortcuts.map { shortcut ->
               val cacheKey = "search_shortcut_${shortcut.id}"
               var icon = iconRepository.getMemory(cacheKey)
@@ -1298,14 +1293,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             }
           } else {
             val sortedShortcuts =
-              shortcuts.sortedWith(
-                compareByDescending<AppSearchDocument> { doc ->
-                    getGlobalUsageCount(doc.namespace, doc.id) +
-                      getDefaultSearchShortcutBoost(doc.id)
-                  }
-                  .thenBy { doc -> DefaultShortcuts.searchShortcutOrder(doc.id) }
-                  .thenBy { doc -> doc.name }
-              )
+              SearchOptions.rankByUsage(shortcuts, { it.id }, { it.name }) { id ->
+                getGlobalUsageCount(SearchOptions.NAMESPACE, id)
+              }
             coroutineScope {
               sortedShortcuts
                 .map { doc -> async { convertDocumentToResult(wrap(doc), 100, saveToDisk = true) } }
@@ -1320,13 +1310,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         Sentry.captureException(e)
         return@withContext emptyList()
       }
-    }
-
-  private fun getDefaultSearchShortcutBoost(id: String): Int =
-    when (id.removePrefix("search_")) {
-      "google" -> 2
-      "playstore" -> 1
-      else -> 0
     }
 
   suspend fun reportUsage(
@@ -1370,11 +1353,12 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
         // Manual usage persistence. Global usage is deliberately weak during ranking; query usage
         // captures "when I type these letters, prefer this result".
-        val usageKey = usageKey(namespace, id)
+        val storedId = canonicalUsageId(namespace, id)
+        val usageKey = usageKey(namespace, storedId)
         usageStats[usageKey] = (usageStats[usageKey] ?: 0) + 1
         _usageRevision.update { it + 1 }
         normalizedUsageQuery(query)?.let { normalizedQuery ->
-          recordQueryUsage(normalizedQuery, namespace, id)
+          recordQueryUsage(normalizedQuery, namespace, storedId)
         }
         saveUsageStats()
 
@@ -2387,8 +2371,35 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private fun normalizedUsageQuery(query: String?): String? =
     query?.trim()?.lowercase()?.replace(Regex("\\s+"), " ")?.takeIf { it.isNotEmpty() }
 
-  private fun getGlobalUsageCount(namespace: String, id: String): Int =
-    usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
+  private fun searchShortcutAliasToId(alias: String): String? =
+    (context.applicationContext as? SearchLauncherApp)
+      ?.searchShortcutRepository
+      ?.items
+      ?.value
+      ?.find { it.alias.equals(alias, ignoreCase = true) }
+      ?.id
+
+  private fun canonicalUsageId(namespace: String, id: String): String =
+    if (namespace == SearchOptions.NAMESPACE) {
+      SearchOptions.canonicalId(id, ::searchShortcutAliasToId)
+    } else {
+      id
+    }
+
+  private fun getGlobalUsageCount(namespace: String, id: String): Int {
+    if (namespace != SearchOptions.NAMESPACE) {
+      return usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
+    }
+    for (alias in SearchOptions.usageIdAliases(id, ::searchShortcutAliasToId)) {
+      usageStats[usageKey(namespace, alias)]?.let {
+        return it
+      }
+      usageStats[alias]?.let {
+        return it
+      }
+    }
+    return 0
+  }
 
   private fun recordQueryUsage(query: String, namespace: String, id: String) {
     val queryLength = query.length.coerceAtLeast(1)

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -180,7 +180,8 @@ fun SearchScreen(
       val (favored, extras) = SearchOptions.partition(searchShortcuts, searchOptionIds)
       fun intents(list: List<SearchShortcut>) =
         list.map { it.toSearchIntent(iconGenerator.getColoredSearchIcon(it.color, it.alias)) }
-      // Only the fill slots are usage-ordered; [favored] keeps the order the user dragged it into.
+      // Same usage order as the shortcut results appended below the query. [favored] stays in
+      // drag order; only the fill slots move when a shortcut is used.
       val ranked =
         SearchOptions.byUsage(extras) {
           searchRepository.globalUsage(SearchOptions.NAMESPACE, it.id)

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -72,8 +72,10 @@ import com.searchlauncher.app.data.SearchOptions
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.SearchShortcut
+import com.searchlauncher.app.data.applyHistoryLimit
 import com.searchlauncher.app.data.favoriteKey
 import com.searchlauncher.app.data.isFavoritable
+import com.searchlauncher.app.data.mergeRecentsByTime
 import com.searchlauncher.app.ui.browser.BrowserActivity
 import com.searchlauncher.app.ui.browser.BrowserTab
 import com.searchlauncher.app.ui.browser.BrowserTabStore
@@ -87,6 +89,7 @@ import com.searchlauncher.app.ui.browser.TAB_STRIP_LABEL_HEIGHT
 import com.searchlauncher.app.ui.browser.browserDestination
 import com.searchlauncher.app.ui.browser.browserTabSwipe
 import com.searchlauncher.app.ui.browser.indexOfTabShowing
+import com.searchlauncher.app.ui.browser.openTabsAsRecents
 import com.searchlauncher.app.ui.browser.rememberBrowserTabSwipeState
 import com.searchlauncher.app.ui.components.BookmarkDialog
 import com.searchlauncher.app.ui.components.ConsentDialog
@@ -230,13 +233,21 @@ fun SearchScreen(
   // Sync back to the boot cache so the next cold start renders at this size immediately.
   LaunchedEffect(minIconSizeSetting) { MinIconSize.updateCache(context, minIconSizeSetting) }
 
+  val openTabRecents = openTabsAsRecents(context)
+  val historyEntries by app.historyRepository.historyEntries.collectAsState()
   val historyItems =
-    remember(rawHistoryItems, favoriteIds, historyLimit) {
+    remember(rawHistoryItems, favoriteIds, historyLimit, openTabRecents, historyEntries) {
       if (historyLimit == 0) emptyList()
       else {
         val favoriteKeys = favoriteIds.toSet()
-        val filtered = rawHistoryItems.filter { it.favoriteKey !in favoriteKeys }
-        if (historyLimit >= 0) filtered.take(historyLimit) else filtered
+        val filteredApps = rawHistoryItems.filter { it.favoriteKey !in favoriteKeys }
+        val merged =
+          mergeRecentsByTime(
+            filteredApps,
+            historyEntries.associate { it.id to it.lastUsedMs },
+            openTabRecents,
+          )
+        applyHistoryLimit(merged.map { it.result }, historyLimit)
       }
     }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -186,7 +186,7 @@ fun SettingsScreen(
             Text(text = "Rows", style = MaterialTheme.typography.bodyMedium)
             Text(
               text =
-                "Add another row when favorites no longer fit. Recents fill leftover spots on the last row.",
+                "Auto wraps when favorites overflow. A number always uses that many rows, filled with recents.",
               style = MaterialTheme.typography.labelSmall,
               color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             )

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -88,6 +88,7 @@ import com.searchlauncher.app.ui.browser.AdBlocker
 import com.searchlauncher.app.ui.components.FAVORITES_MAX_ROWS_AUTO
 import com.searchlauncher.app.ui.components.PrivacyPolicyDialog
 import com.searchlauncher.app.ui.components.loadPrivacyPolicyText
+import com.searchlauncher.app.ui.components.shouldShowFavoritesIconSizeSetting
 import com.searchlauncher.app.util.CustomActionHandler
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -270,7 +271,10 @@ fun SettingsScreen(
               }
             }
 
-            AnimatedVisibility(visible = historyLimit.value != 0) {
+            AnimatedVisibility(
+              visible =
+                shouldShowFavoritesIconSizeSetting(historyLimit.value, favoritesMaxRows.value)
+            ) {
               val minIconSize =
                 remember {
                     context.dataStore.data.map {
@@ -338,8 +342,11 @@ fun SettingsScreen(
                 )
                 Text(
                   text =
-                    if (historyLimit.value == -1) "Smaller icons allow more history items to fit."
-                    else "Adjust the maximum size for your favorite and history icons.",
+                    when {
+                      favoritesMaxRows.value > 0 -> "Larger icons mean fewer apps on each row."
+                      historyLimit.value == -1 -> "Smaller icons allow more history items to fit."
+                      else -> "Adjust the maximum size for your favorite and history icons."
+                    },
                   style = MaterialTheme.typography.labelSmall,
                   color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                 )

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -114,7 +114,9 @@ import coil.compose.AsyncImage
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.applyHistoryLimit
 import com.searchlauncher.app.data.favoriteKey
+import com.searchlauncher.app.data.mergeRecentsByTime
 import com.searchlauncher.app.ui.KeyShortcutHost
 import com.searchlauncher.app.ui.KeyShortcuts
 import com.searchlauncher.app.ui.MainActivity
@@ -543,13 +545,31 @@ internal fun BrowserScreen(
         }
       }
       .collectAsState(initial = FAVORITES_MAX_ROWS_AUTO)
+  val noEntries = remember {
+    MutableStateFlow(emptyList<com.searchlauncher.app.data.HistoryEntry>())
+  }
+  val historyEntries by (app.historyRepositoryOrNull?.historyEntries ?: noEntries).collectAsState()
+  val openTabRecents = if (privateMode) emptyList() else openTabsAsRecents(context)
   val historyItems =
-    remember(allRecentItems, favoriteIds, historyLimit, privateMode) {
+    remember(
+      allRecentItems,
+      favoriteIds,
+      historyLimit,
+      privateMode,
+      openTabRecents,
+      historyEntries,
+    ) {
       if (privateMode || historyLimit == 0) emptyList()
       else {
         val favoriteKeys = favoriteIds.toSet()
-        val filtered = allRecentItems.filter { it.favoriteKey !in favoriteKeys }
-        if (historyLimit >= 0) filtered.take(historyLimit) else filtered
+        val filteredApps = allRecentItems.filter { it.favoriteKey !in favoriteKeys }
+        val merged =
+          mergeRecentsByTime(
+            filteredApps,
+            historyEntries.associate { it.id to it.lastUsedMs },
+            openTabRecents,
+          )
+        applyHistoryLimit(merged.map { it.result }, historyLimit)
       }
     }
   // Hidden by default while browsing: the page is the focus, and the row is a lot of UI.

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserTabs.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserTabs.kt
@@ -1,7 +1,9 @@
 package com.searchlauncher.app.ui.browser
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.webkit.WebView
 import androidx.compose.runtime.Stable
@@ -12,6 +14,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.searchlauncher.app.R
+import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.TimedRecent
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.abs
 
@@ -22,6 +27,8 @@ import kotlin.math.abs
  */
 internal class BrowserTab(initialUrl: String, restoredId: Long? = null) {
   val id: Long = restoredId ?: System.nanoTime()
+  /** Wall-clock time this tab was opened, used to sit it among app recents. */
+  val openedAtMs: Long = System.currentTimeMillis()
   var url by mutableStateOf(initialUrl)
   var title by mutableStateOf<String?>(null)
   var desktopMode by mutableStateOf(false)
@@ -428,4 +435,29 @@ private fun Bitmap.scaledToWidth(targetWidth: Int): Bitmap? {
   val targetHeight = (height.toFloat() * targetWidth / width).toInt().coerceAtLeast(1)
   return runCatching { Bitmap.createScaledBitmap(this, targetWidth, targetHeight, true) }
     .getOrNull()
+}
+
+/** Recents / search result for an open tab. Blank `about:` pages have nothing to show. */
+internal fun BrowserTab.toSearchResult(context: Context): SearchResult.BrowserTab? {
+  if (url.startsWith("about:")) return null
+  val address = url.removePrefix("https://").removePrefix("http://").removeSuffix("/")
+  val pageTitle = title?.takeUnless(String::isBlank)
+  val icon =
+    favicon?.takeUnless { it.isRecycled }?.let { BitmapDrawable(context.resources, it) }
+      ?: runCatching { context.getDrawable(R.drawable.ic_globe) }.getOrNull()
+  return SearchResult.BrowserTab(
+    id = "browser_tab_$id",
+    title = pageTitle ?: address.ifBlank { "Tab" },
+    subtitle = "Open tab",
+    icon = icon,
+    tabId = id,
+    url = url,
+  )
+}
+
+internal fun openTabsAsRecents(context: Context): List<TimedRecent> {
+  val tabs = BrowserTabStore.tabs?.items ?: return emptyList()
+  return tabs.mapNotNull { tab ->
+    tab.toSearchResult(context)?.let { TimedRecent(it, tab.openedAtMs) }
+  }
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -1,11 +1,11 @@
 package com.searchlauncher.app.ui.components
 
 /**
- * How many rows the favorites bar may grow to.
+ * How many rows the favorites bar uses.
  *
  * `-1` means Auto: add a row when pinned favorites no longer fit at the preferred icon size, up to
- * [FAVORITES_MAX_ROWS_CAP]. `1`–`4` cap growth at that many rows; overflowing items shrink to fit,
- * which is the original single-row behaviour when the cap is 1.
+ * [FAVORITES_MAX_ROWS_CAP]. `1`–`4` always use that many rows, filling leftover cells with recents.
+ * Overflowing favorites shrink to fit.
  */
 const val FAVORITES_MAX_ROWS_AUTO = -1
 const val FAVORITES_MAX_ROWS_CAP = 4
@@ -17,7 +17,7 @@ internal data class FavoritesBarLayout(
   val iconSizePx: Float,
   val historyCapacity: Int,
   val showDivider: Boolean,
-  /** Pinned items sitting on the last row; the divider (if any) follows this many. */
+  /** Pinned items on the row that holds the divider; the divider (if any) follows this many. */
   val lastRowFavoriteCount: Int,
 )
 
@@ -48,11 +48,10 @@ internal fun ceilDiv(value: Int, divisor: Int): Int {
 }
 
 /**
- * Decide rows, grid width, icon size, and how many history items the last row can take.
+ * Decide rows, grid width, icon size, and how many history items leftover cells can take.
  *
- * Rows grow for overflowing favorites first. History then fills leftover slots on the last row; a
- * fixed history limit may shrink icons so that many items still fit in the chosen row count. Auto
- * history never adds a row of its own.
+ * Auto grows only when favorites overflow. A fixed count always uses that many rows and fills the
+ * extra cells with recents. A fixed history limit may shrink icons so that many items still fit.
  */
 internal fun computeFavoritesBarLayout(
   totalWidthPx: Float,
@@ -65,6 +64,7 @@ internal fun computeFavoritesBarLayout(
   expandToFill: Boolean,
   maxRowsSetting: Int,
 ): FavoritesBarLayout {
+  val autoRows = maxRowsSetting < 0
   val maxRows = resolveFavoritesMaxRows(maxRowsSetting)
   val preferredPerRow = itemsThatFit(totalWidthPx, minIconSizePx, spacingPx).coerceAtLeast(1)
 
@@ -72,8 +72,9 @@ internal fun computeFavoritesBarLayout(
     if (favoriteCount <= 0) 0 else ceilDiv(favoriteCount, preferredPerRow).coerceAtLeast(1)
   val rowCount =
     when {
-      favoriteCount <= 0 -> 1
-      else -> favRows.coerceIn(1, maxRows)
+      autoRows && favoriteCount <= 0 -> 1
+      autoRows -> favRows.coerceIn(1, maxRows)
+      else -> maxRows
     }
 
   var itemsPerRow =
@@ -83,19 +84,19 @@ internal fun computeFavoritesBarLayout(
       preferredPerRow
     }
 
-  fun lastRowFavs(perRow: Int): Int {
-    if (favoriteCount <= 0) return 0
-    val fullRows = (rowCount - 1).coerceAtLeast(0)
-    return (favoriteCount - fullRows * perRow).coerceIn(1, perRow)
+  /** Favorites sitting on the row that holds the first leftover / history cell. */
+  fun favsOnBoundaryRow(perRow: Int): Int {
+    if (favoriteCount <= 0 || perRow <= 0) return 0
+    val rem = favoriteCount % perRow
+    return if (rem == 0) perRow else rem
   }
 
-  fun historySlots(perRow: Int, lastFavs: Int): Int {
+  fun historySlots(perRow: Int, boundaryFavs: Int): Int {
     if (historyLimit == 0) return 0
-    // A multi-row bar is a grid: leftover cells on the last row fill with recents. The divider
-    // sits in existing spacing so it does not steal a slot. A single row still reserves the
-    // original gap, matching the old dock.
-    if (rowCount > 1) return (perRow - lastFavs).coerceAtLeast(0)
-    val gap = if (drawDivider && lastFavs > 0) dividerGapPx else 0f
+    // A multi-row bar is a grid: every leftover cell fills with recents. The divider sits in
+    // existing spacing so it does not steal a slot. A single row still reserves the original gap.
+    if (rowCount > 1) return (rowCount * perRow - favoriteCount).coerceAtLeast(0)
+    val gap = if (drawDivider && boundaryFavs > 0) dividerGapPx else 0f
     val lastRowCap =
       if (gap > 0f) {
         if (perRow > preferredPerRow) perRow
@@ -103,10 +104,10 @@ internal fun computeFavoritesBarLayout(
       } else {
         perRow
       }
-    return (lastRowCap - lastFavs).coerceAtLeast(0)
+    return (lastRowCap - boundaryFavs).coerceAtLeast(0)
   }
 
-  var lastFavs = lastRowFavs(itemsPerRow)
+  var lastFavs = favsOnBoundaryRow(itemsPerRow)
   var slots = historySlots(itemsPerRow, lastFavs)
 
   val historyCapacity =
@@ -117,8 +118,8 @@ internal fun computeFavoritesBarLayout(
         if (wanted > slots) {
           val totalWanted = favoriteCount + wanted
           itemsPerRow = ceilDiv(totalWanted, rowCount).coerceAtLeast(1)
-          lastFavs = lastRowFavs(itemsPerRow)
-          slots = (itemsPerRow - lastFavs).coerceAtLeast(0)
+          lastFavs = favsOnBoundaryRow(itemsPerRow)
+          slots = (rowCount * itemsPerRow - favoriteCount).coerceAtLeast(0)
         }
         wanted.coerceAtMost(slots)
       }
@@ -127,7 +128,7 @@ internal fun computeFavoritesBarLayout(
 
   val visibleTotal = favoriteCount + historyCapacity
   val showDivider = drawDivider && favoriteCount > 0 && historyCapacity > 0
-  lastFavs = lastRowFavs(itemsPerRow)
+  lastFavs = favsOnBoundaryRow(itemsPerRow)
 
   val fullestRow = if (rowCount <= 1) visibleTotal.coerceAtLeast(1) else itemsPerRow
   val gapForSize = if (rowCount <= 1 && showDivider) dividerGapPx else 0f

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -24,6 +24,10 @@ internal data class FavoritesBarLayout(
 internal fun resolveFavoritesMaxRows(setting: Int): Int =
   if (setting < 0) FAVORITES_MAX_ROWS_CAP else setting.coerceIn(1, FAVORITES_MAX_ROWS_CAP)
 
+/** Icon size is useful whenever history can pack a row, or a fixed row count sizes the grid. */
+internal fun shouldShowFavoritesIconSizeSetting(historyLimit: Int, maxRowsSetting: Int): Boolean =
+  historyLimit != 0 || maxRowsSetting > 0
+
 /**
  * How many icons fit in [totalWidthPx] at [iconSizePx], matching the original single-row formula
  * (slightly generous via `+ spacing/2` so a near-fit still counts).

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -174,6 +174,12 @@ internal fun computeIconSizePx(
   }
 }
 
+/** Newest-first history, left to right unless [reverse] puts the newest at the trailing end. */
+internal fun <T> takeHistoryForDisplay(history: List<T>, capacity: Int, reverse: Boolean): List<T> {
+  val visible = history.take(capacity.coerceAtLeast(0))
+  return if (reverse) visible.reversed() else visible
+}
+
 internal fun itemRow(index: Int, itemsPerRow: Int): Int =
   if (itemsPerRow <= 0) 0 else index / itemsPerRow
 

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.favoriteKey
+import com.searchlauncher.app.data.isFavoritable
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.ThemedIcons
 import com.searchlauncher.app.ui.dataStore
@@ -337,7 +338,7 @@ fun FavoritesRow(
                         val wasFavorite = favorites.any { it.favoriteKey == draggedId }
                         val isNowInFavoriteZone = finalIdx < boundaryIndex
 
-                        if (!wasFavorite && isNowInFavoriteZone) {
+                        if (!wasFavorite && isNowInFavoriteZone && result.isFavoritable()) {
                           onToggleFavorite(result)
                         } else if (wasFavorite && isNowInFavoriteZone) {
                           onReorder(currentOrder.take(boundaryIndex))

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -82,8 +82,8 @@ fun FavoritesRow(
    */
   menuActions: ((SearchResult) -> ResultMenuActions)? = null,
   /**
-   * How many rows pinned favorites may wrap onto. [FAVORITES_MAX_ROWS_AUTO] grows as needed (up to
-   * [FAVORITES_MAX_ROWS_CAP]); `1`–`4` cap growth at that many rows.
+   * How many rows the bar uses. [FAVORITES_MAX_ROWS_AUTO] grows as needed (up to
+   * [FAVORITES_MAX_ROWS_CAP]); `1`–`4` always use that many rows, filled with recents.
    */
   maxRows: Int = FAVORITES_MAX_ROWS_AUTO,
 ) {
@@ -217,8 +217,11 @@ fun FavoritesRow(
         showDivider
       }
     val effectiveLastRowFavs =
-      if (rowCount <= 1) effectiveBoundary
-      else (effectiveBoundary - itemsPerRow * (rowCount - 1)).coerceIn(0, itemsPerRow)
+      if (rowCount <= 1 || itemsPerRow <= 0) effectiveBoundary
+      else {
+        val rem = effectiveBoundary % itemsPerRow
+        if (rem == 0) 0 else rem
+      }
 
     fun xForIndex(index: Int): Float =
       itemX(
@@ -243,7 +246,7 @@ fun FavoritesRow(
         val dividerX =
           if (rowCount > 1) xForIndex(dividerIndex) - (spacingPx / 2)
           else xForIndex(dividerIndex) - (dividerGapPx / 2) - (spacingPx / 2)
-        val dividerY = yForIndex((rowCount - 1) * itemsPerRow)
+        val dividerY = yForIndex(dividerIndex)
         Box(
           modifier =
             Modifier.offset(

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -71,8 +71,11 @@ fun FavoritesRow(
    * than would fill it at [minIconSizeSetting].
    */
   expandToFill: Boolean = false,
-  /** History is newest-first and sits against the divider; set false to keep the given order. */
-  reverseHistory: Boolean = true,
+  /**
+   * History is newest-first. Default keeps that left to right after the favorites. Set true to
+   * reverse the slice so the newest sits at the trailing end instead.
+   */
+  reverseHistory: Boolean = false,
   /** Draw the gap between pinned items and the fill/history items. */
   drawDivider: Boolean = true,
   /**
@@ -135,8 +138,7 @@ fun FavoritesRow(
 
     val visibleHistory =
       remember(history, measured.historyCapacity, reverseHistory) {
-        val visible = history.take(measured.historyCapacity)
-        if (reverseHistory) visible.reversed() else visible
+        takeHistoryForDisplay(history, measured.historyCapacity, reverseHistory)
       }
 
     val allItems = favorites + visibleHistory

--- a/app/src/test/java/com/searchlauncher/app/data/HistoryRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/HistoryRepositoryTest.kt
@@ -1,0 +1,51 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class HistoryRepositoryTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+    context.getSharedPreferences(Prefs.History.FILE, Context.MODE_PRIVATE).edit().clear().commit()
+  }
+
+  @Test
+  fun `addHistoryItem moves the id to the front and stamps the time`() {
+    val repo = HistoryRepository(context)
+    repo.addHistoryItem("a", atMs = 1000L)
+    repo.addHistoryItem("b", atMs = 2000L)
+    repo.addHistoryItem("a", atMs = 3000L)
+
+    assertEquals(listOf("a", "b"), repo.historyIds.value)
+    assertEquals(3000L, repo.timesById()["a"])
+    assertEquals(2000L, repo.timesById()["b"])
+  }
+
+  @Test
+  fun `legacy ids without times keep their order`() {
+    context
+      .getSharedPreferences(Prefs.History.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .putString(Prefs.History.IDS, """["one","two","three"]""")
+      .commit()
+
+    val repo = HistoryRepository(context)
+    assertEquals(listOf("one", "two", "three"), repo.historyIds.value)
+    val times = repo.historyEntries.value.map { it.lastUsedMs }
+    assertTrue(times[0] > times[1])
+    assertTrue(times[1] > times[2])
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/RecentsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/RecentsTest.kt
@@ -1,0 +1,78 @@
+package com.searchlauncher.app.data
+
+import android.graphics.drawable.ColorDrawable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RecentsTest {
+  private val icon = ColorDrawable(0)
+
+  private fun app(pkg: String) =
+    SearchResult.App(
+      id = pkg,
+      namespace = "apps",
+      title = pkg,
+      subtitle = null,
+      icon = icon,
+      packageName = pkg,
+    )
+
+  private fun tab(tabId: Long, url: String) =
+    SearchResult.BrowserTab(
+      id = "browser_tab_$tabId",
+      title = url,
+      subtitle = "Open tab",
+      icon = icon,
+      tabId = tabId,
+      url = url,
+    )
+
+  @Test
+  fun `a newer tab sits ahead of an older app`() {
+    val settings = app("com.android.settings")
+    val merged =
+      mergeRecentsByTime(
+        apps = listOf(settings),
+        appTimes = mapOf("com.android.settings" to 1000L),
+        tabs = listOf(TimedRecent(tab(1, "https://example.com"), atMs = 2000L)),
+      )
+
+    assertEquals(listOf("browser_tab_1", "com.android.settings"), merged.map { it.result.id })
+  }
+
+  @Test
+  fun `a newer app sits ahead of an older tab`() {
+    val settings = app("com.android.settings")
+    val merged =
+      mergeRecentsByTime(
+        apps = listOf(settings),
+        appTimes = mapOf("com.android.settings" to 3000L),
+        tabs = listOf(TimedRecent(tab(1, "https://example.com"), atMs = 2000L)),
+      )
+
+    assertEquals(listOf("com.android.settings", "browser_tab_1"), merged.map { it.result.id })
+  }
+
+  @Test
+  fun `tabs keep open order among themselves`() {
+    val older = TimedRecent(tab(1, "https://one.example"), atMs = 1000L)
+    val newer = TimedRecent(tab(2, "https://two.example"), atMs = 2000L)
+    val merged =
+      mergeRecentsByTime(apps = emptyList(), appTimes = emptyMap(), tabs = listOf(older, newer))
+
+    assertEquals(listOf("browser_tab_2", "browser_tab_1"), merged.map { it.result.id })
+  }
+
+  @Test
+  fun `app times resolve by favorite key`() {
+    val settings = app("com.android.settings")
+    val merged =
+      mergeRecentsByTime(
+        apps = listOf(settings),
+        appTimes = mapOf("apps/com.android.settings" to 5000L),
+        tabs = listOf(TimedRecent(tab(1, "https://example.com"), atMs = 1000L)),
+      )
+
+    assertEquals("com.android.settings", merged.first().result.id)
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/SearchOptionsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchOptionsTest.kt
@@ -57,10 +57,42 @@ class SearchOptionsTest {
   }
 
   @Test
-  fun `byUsage keeps unused options in their incoming order`() {
+  fun `byUsage applies the same unused tilt as results`() {
     val ordered = SearchOptions.byUsage(shortcuts) { 0 }
 
-    assertEquals(shortcuts.map { it.id }, ordered.map { it.id })
+    assertEquals("google", ordered[0].id)
+    assertEquals("playstore", ordered[1].id)
+  }
+
+  @Test
+  fun `canonicalId collapses indexed and alias result ids`() {
+    assertEquals("google", SearchOptions.canonicalId("google"))
+    assertEquals("google", SearchOptions.canonicalId("search_google"))
+    assertEquals("google", SearchOptions.canonicalId("search_shortcuts/google"))
+    assertEquals(
+      "google",
+      SearchOptions.canonicalId("shortcut_g") { alias -> if (alias == "g") "google" else null },
+    )
+  }
+
+  @Test
+  fun `usage aliases include the indexed search_ id the results list records`() {
+    val aliases = SearchOptions.usageIdAliases("google")
+    assertTrue("google" in aliases)
+    assertTrue("search_google" in aliases)
+  }
+
+  @Test
+  fun `rankByUsage matches results when usage was stored under search_google`() {
+    val extras = SearchOptions.partition(shortcuts, SearchOptions.DEFAULT_FAVORITE_IDS).second
+    val stored = mapOf("search_wikipedia" to 8, "search_bing" to 3)
+    val ranked =
+      SearchOptions.rankByUsage(extras, { it.id }, { it.description }) { id ->
+        SearchOptions.usageIdAliases(id).maxOf { stored[it] ?: 0 }
+      }
+
+    assertEquals("wikipedia", ranked.first().id)
+    assertEquals("bing", ranked[1].id)
   }
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserTabRecentsTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserTabRecentsTest.kt
@@ -1,0 +1,33 @@
+package com.searchlauncher.app.ui.browser
+
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class BrowserTabRecentsTest {
+  @Test
+  fun `blank tabs are not offered as recents`() {
+    val context = ApplicationProvider.getApplicationContext<SearchLauncherApp>()
+    assertNull(BrowserTab("about:blank").toSearchResult(context))
+  }
+
+  @Test
+  fun `an open page becomes a browser tab result with its url`() {
+    val context = ApplicationProvider.getApplicationContext<SearchLauncherApp>()
+    val tab = BrowserTab("https://example.com/page")
+    tab.title = "Example"
+    val result = tab.toSearchResult(context)!!
+
+    assertEquals("Example", result.title)
+    assertEquals("Open tab", result.subtitle)
+    assertEquals(tab.id, result.tabId)
+    assertEquals("https://example.com/page", result.url)
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -193,6 +193,19 @@ class FavoritesBarLayoutTest {
   }
 
   @Test
+  fun `recents stay newest-first left to right`() {
+    val newestFirst = listOf("camera", "gallery", "messages", "files")
+    assertEquals(
+      listOf("camera", "gallery", "messages"),
+      takeHistoryForDisplay(newestFirst, capacity = 3, reverse = false),
+    )
+    assertEquals(
+      listOf("messages", "gallery", "camera"),
+      takeHistoryForDisplay(newestFirst, capacity = 3, reverse = true),
+    )
+  }
+
+  @Test
   fun `item cells are row-major`() {
     assertEquals(0, itemRow(4, itemsPerRow = 6))
     assertEquals(4, itemCol(4, itemsPerRow = 6))

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -81,6 +81,17 @@ class FavoritesBarLayoutTest {
   }
 
   @Test
+  fun `a fixed row count uses that many rows and fills leftover cells with recents`() {
+    val result = layout(favorites = 4, maxRows = 2)
+    assertEquals(2, result.rowCount)
+    assertEquals(10, result.itemsPerRow)
+    // Two rows of 10 minus 4 favorites = 16 recents.
+    assertEquals(16, result.historyCapacity)
+    assertEquals(4, result.lastRowFavoriteCount)
+    assertEquals(icon, result.iconSizePx, 0.01f)
+  }
+
+  @Test
   fun `auto history never adds a row of its own`() {
     val few = layout(favorites = 3, historyLimit = -1)
     assertEquals(1, few.rowCount)

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -145,6 +145,54 @@ class FavoritesBarLayoutTest {
   }
 
   @Test
+  fun `icon size stays available for a fixed row count even when history is auto`() {
+    assertTrue(shouldShowFavoritesIconSizeSetting(historyLimit = -1, maxRowsSetting = 2))
+    assertTrue(shouldShowFavoritesIconSizeSetting(historyLimit = 0, maxRowsSetting = 2))
+    assertTrue(shouldShowFavoritesIconSizeSetting(historyLimit = 5, maxRowsSetting = 2))
+    assertTrue(
+      shouldShowFavoritesIconSizeSetting(
+        historyLimit = -1,
+        maxRowsSetting = FAVORITES_MAX_ROWS_AUTO,
+      )
+    )
+    assertFalse(
+      shouldShowFavoritesIconSizeSetting(historyLimit = 0, maxRowsSetting = FAVORITES_MAX_ROWS_AUTO)
+    )
+  }
+
+  @Test
+  fun `a larger icon size still applies with a fixed row count and auto history`() {
+    val compact =
+      computeFavoritesBarLayout(
+        totalWidthPx = width,
+        favoriteCount = 4,
+        historyLimit = -1,
+        minIconSizePx = 32f,
+        spacingPx = spacing,
+        dividerGapPx = divider,
+        drawDivider = true,
+        expandToFill = false,
+        maxRowsSetting = 2,
+      )
+    val large =
+      computeFavoritesBarLayout(
+        totalWidthPx = width,
+        favoriteCount = 4,
+        historyLimit = -1,
+        minIconSizePx = 64f,
+        spacingPx = spacing,
+        dividerGapPx = divider,
+        drawDivider = true,
+        expandToFill = false,
+        maxRowsSetting = 2,
+      )
+    assertEquals(2, compact.rowCount)
+    assertEquals(2, large.rowCount)
+    assertTrue(large.iconSizePx > compact.iconSizePx)
+    assertTrue(large.itemsPerRow < compact.itemsPerRow)
+  }
+
+  @Test
   fun `item cells are row-major`() {
     assertEquals(0, itemRow(4, itemsPerRow = 6))
     assertEquals(4, itemCol(4, itemsPerRow = 6))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Choosing **2**, **3**, or **4** in Settings → Favorites bar → Rows stayed on one row when pinned favorites still fit. Auto looked like it worked because it wraps on overflow; a number was only a cap.

A fixed count now always builds that many rows and fills leftover grid cells with recents. Auto is unchanged: wrap only when favorites overflow, up to 4.

Icon size stays visible whenever a number of rows is set, including when history is Auto.

Recents are newest-first **left to right**. Open browser tabs now sit in that same strip, ordered by when they were opened, with the page favicon.

Query-time search options use the same usage order as shortcut results.

## What changed
- Fixed row count always uses N rows, filled with recents.
- Icon size slider stays visible for a fixed row count.
- Recents: newest-first left to right; open tabs interleave by open time.
- Search-option fill slots follow results usage (canonical shortcut ids).

## Test plan
- [x] `FavoritesBarLayoutTest`, `SearchOptionsTest`, `RecentsTest`, `HistoryRepositoryTest`, `BrowserTabRecentsTest`
- [x] Emulator: Rows=2, icon size, recents LTR, query-time shortcut usage
- [x] Emulator: open https://example.com, return Home (not Back), tab title “Example Domain” sits first among recents after the divider, with the globe favicon; search bar shows 1 open tab

[Open tab Example Domain in favorites recents](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen_tab_example_domain_in_recents.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

