### PR TITLE
Fix Set as Default Browser button

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/util/CustomActionHandler.kt
+++ b/app/src/main/java/com/searchlauncher/app/util/CustomActionHandler.kt
@@ -1,7 +1,9 @@
 package com.searchlauncher.app.util
 
+import android.app.Activity
 import android.app.role.RoleManager
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.hardware.camera2.CameraManager
 import android.net.Uri
@@ -221,7 +223,14 @@ object CustomActionHandler {
     }
   }
 
+  /**
+   * [RoleManager.createRequestRoleIntent] must be started with [Activity.startActivityForResult].
+   * The system picker reads [Activity.getCallingPackage], which is only set for a for-result launch
+   * — [Context.startActivity] makes the picker finish immediately, so the settings button appeared
+   * to do nothing.
+   */
   private fun requestDefaultBrowserRole(context: Context) {
+    val activity = context.findActivity()
     try {
       val roleManager = context.getSystemService(Context.ROLE_SERVICE) as RoleManager
       if (roleManager.isRoleHeld(RoleManager.ROLE_BROWSER)) {
@@ -233,20 +242,26 @@ object CustomActionHandler {
           .show()
         return
       }
-      if (roleManager.isRoleAvailable(RoleManager.ROLE_BROWSER)) {
-        // No FLAG_ACTIVITY_NEW_TASK: the role picker expects to return a result to the calling
-        // task, and callers here are always a real foreground Activity context (never
-        // ApplicationContext). Requesting a new task made the system dialog silently no-op on
-        // some devices instead of showing.
-        context.startActivity(roleManager.createRequestRoleIntent(RoleManager.ROLE_BROWSER))
+      if (activity != null && roleManager.isRoleAvailable(RoleManager.ROLE_BROWSER)) {
+        @Suppress("DEPRECATION")
+        activity.startActivityForResult(
+          roleManager.createRequestRoleIntent(RoleManager.ROLE_BROWSER),
+          REQUEST_DEFAULT_BROWSER,
+        )
         return
       }
     } catch (e: Exception) {
       e.printStackTrace()
       // Fall through to the manual default-apps settings screen below.
     }
+    openDefaultAppsSettings(context)
+  }
+
+  private fun openDefaultAppsSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+    if (context.findActivity() == null) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     try {
-      context.startActivity(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
+      context.startActivity(intent)
     } catch (e: Exception) {
       Toast.makeText(context, "Default apps settings not available", Toast.LENGTH_SHORT).show()
     }
@@ -263,4 +278,16 @@ object CustomActionHandler {
       Toast.makeText(context, "Developer options not available", Toast.LENGTH_SHORT).show()
     }
   }
+
+  private const val REQUEST_DEFAULT_BROWSER = 0x51B0
+}
+
+/** Walks [ContextWrapper]s so a Compose [LocalContext] still finds its Activity. */
+internal fun Context.findActivity(): Activity? {
+  var current: Context? = this
+  while (current is ContextWrapper) {
+    if (current is Activity) return current
+    current = current.baseContext
+  }
+  return null
 }

--- a/app/src/test/java/com/searchlauncher/app/util/CustomActionHandlerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/util/CustomActionHandlerTest.kt
@@ -1,17 +1,25 @@
 package com.searchlauncher.app.util
 
+import android.app.Activity
+import android.app.role.RoleManager
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
 class CustomActionHandlerTest {
 
   private val context = ApplicationProvider.getApplicationContext<Context>()
@@ -51,5 +59,56 @@ class CustomActionHandlerTest {
 
     // Should go back to 0
     assertEquals(0, Settings.System.getInt(resolver, Settings.System.ACCELEROMETER_ROTATION))
+  }
+
+  @Test
+  fun `set default browser starts the role request for a result`() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val roleManager = activity.getSystemService(Context.ROLE_SERVICE) as RoleManager
+    shadowOf(roleManager).addAvailableRole(RoleManager.ROLE_BROWSER)
+
+    assertTrue(
+      CustomActionHandler.handleAction(
+        activity,
+        Intent("com.searchlauncher.action.SET_DEFAULT_BROWSER"),
+      )
+    )
+
+    val started = shadowOf(activity).nextStartedActivityForResult
+    assertNotNull("role picker must be started for a result", started)
+    assertEquals("android.app.role.action.REQUEST_ROLE", started.intent.action)
+    assertTrue(
+      started.intent.extras?.keySet()?.any {
+        started.intent.getStringExtra(it) == RoleManager.ROLE_BROWSER
+      } == true
+    )
+  }
+
+  @Test
+  fun `set default browser unwraps a themed context to start for result`() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val roleManager = activity.getSystemService(Context.ROLE_SERVICE) as RoleManager
+    shadowOf(roleManager).addAvailableRole(RoleManager.ROLE_BROWSER)
+    val wrapped = ContextWrapper(activity)
+
+    assertEquals(activity, wrapped.findActivity())
+    CustomActionHandler.handleAction(
+      wrapped,
+      Intent("com.searchlauncher.action.SET_DEFAULT_BROWSER"),
+    )
+
+    assertNotNull(shadowOf(activity).nextStartedActivityForResult)
+  }
+
+  @Test
+  fun `set default browser without an activity opens default-apps settings`() {
+    CustomActionHandler.handleAction(
+      context,
+      Intent("com.searchlauncher.action.SET_DEFAULT_BROWSER"),
+    )
+
+    val started = shadowOf(context as android.app.Application).nextStartedActivity
+    assertEquals(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS, started.action)
+    assertTrue(started.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The **Set as Default Browser** button in settings (and the matching search action) launched the role picker with `startActivity`. The system picker reads `getCallingPackage()`, which is only set for a for-result launch, so it finished immediately and the button appeared to do nothing.

This starts the role request with `startActivityForResult` after unwrapping a Compose `LocalContext` to its Activity. If there is no Activity or the browser role is unavailable, it opens default-apps settings instead.

## Test plan
- [x] Unit tests: role request is started for a result; themed context unwraps; Application context falls back to default-apps settings
- [x] On the AOSP emulator, tap **Set as Default Browser** in Settings → Browser — the system picker appears: “Set SearchLauncher (debug) as your default browser app?” with SearchLauncher / WebView Shell and Cancel / Set as default

[Settings button](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_set_as_default_browser_button.png)
[System default-browser picker](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefault_browser_role_picker.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

