### PR TITLE
Keep the favorites bar to one row while searching

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -104,6 +104,7 @@ import com.searchlauncher.app.ui.components.SearchResultItem
 import com.searchlauncher.app.ui.components.ShortcutDialog
 import com.searchlauncher.app.ui.components.SnippetDialog
 import com.searchlauncher.app.ui.components.WallpaperBackground
+import com.searchlauncher.app.ui.components.favoritesMaxRowsForBar
 import com.searchlauncher.app.ui.components.homeWidgetsEnabled
 import com.searchlauncher.app.ui.components.loadPrivacyPolicyText
 import com.searchlauncher.app.ui.onboarding.OnboardingManager
@@ -1010,6 +1011,7 @@ fun SearchScreen(
   var chromeBarHeightPx by remember { mutableIntStateOf(0) }
   var favoritesRowHeightPx by remember { mutableIntStateOf(0) }
   val showingSearchOptions = query.isNotBlank()
+  val barMaxRows = favoritesMaxRowsForBar(showingSearchOptions, favoritesMaxRows)
   val favoritesRowVisible =
     if (showingSearchOptions) {
       searchOptionFavorites.isNotEmpty() || searchOptionExtras.isNotEmpty()
@@ -1710,7 +1712,7 @@ fun SearchScreen(
                   favorites = searchOptionFavorites,
                   history = searchOptionExtras,
                   minIconSizeSetting = minIconSizeSetting,
-                  maxRows = favoritesMaxRows,
+                  maxRows = barMaxRows,
                   expandToFill = true,
                   reverseHistory = false,
                   drawDivider = false,
@@ -1760,7 +1762,7 @@ fun SearchScreen(
                   history = historyItems,
                   historyLimit = historyLimit,
                   minIconSizeSetting = minIconSizeSetting,
-                  maxRows = favoritesMaxRows,
+                  maxRows = barMaxRows,
                   onLaunch = { result ->
                     if (result is SearchResult.SearchIntent) {
                       searchRepository.reportUsageAsync(result.namespace, result.id)

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesBarLayout.kt
@@ -28,6 +28,10 @@ internal fun resolveFavoritesMaxRows(setting: Int): Int =
 internal fun shouldShowFavoritesIconSizeSetting(historyLimit: Int, maxRowsSetting: Int): Boolean =
   historyLimit != 0 || maxRowsSetting > 0
 
+/** A query keeps the bar to one row so results stay on screen. Home still uses the Rows setting. */
+internal fun favoritesMaxRowsForBar(hasQuery: Boolean, setting: Int): Int =
+  if (hasQuery) 1 else setting
+
 /**
  * How many icons fit in [totalWidthPx] at [iconSizePx], matching the original single-row formula
  * (slightly generous via `+ spacing/2` so a near-fit still counts).

--- a/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/FavoritesBarLayoutTest.kt
@@ -206,6 +206,19 @@ class FavoritesBarLayoutTest {
   }
 
   @Test
+  fun `a query forces one row even when the setting allows more`() {
+    assertEquals(1, favoritesMaxRowsForBar(hasQuery = true, setting = 3))
+    assertEquals(1, favoritesMaxRowsForBar(hasQuery = true, setting = FAVORITES_MAX_ROWS_AUTO))
+    assertEquals(3, favoritesMaxRowsForBar(hasQuery = false, setting = 3))
+    assertEquals(
+      FAVORITES_MAX_ROWS_AUTO,
+      favoritesMaxRowsForBar(hasQuery = false, setting = FAVORITES_MAX_ROWS_AUTO),
+    )
+    val searching = layout(favorites = 14, maxRows = favoritesMaxRowsForBar(true, 3))
+    assertEquals(1, searching.rowCount)
+  }
+
+  @Test
   fun `item cells are row-major`() {
     assertEquals(0, itemRow(4, itemsPerRow = 6))
     assertEquals(4, itemCol(4, itemsPerRow = 6))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
While a search query is up, the favorites / search-options bar stays **one row** so results are not pushed down. Clearing the query restores the Rows setting on the home bar.

## Test plan
- [x] `FavoritesBarLayoutTest` — a query forces `maxRows = 1`; home keeps the setting
- [x] Emulator: Rows=2 on home, type `s`, bar is a single row of search options

[Home bar with two rows](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_favorites_two_rows.png)
[Search query keeps the bar to one row](https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_favorites_one_row.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

