### PR TITLE
Fix browser search overlay back button and hide widgets

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -4,8 +4,10 @@ import android.animation.ValueAnimator
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
+import android.window.OnBackInvokedDispatcher
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -18,15 +20,19 @@ import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.ui.browser.BrowserActivity
 
 class SearchActivity : ComponentActivity(), KeyShortcutHost {
-  override var keyShortcutHandler: ((android.view.KeyEvent) -> Boolean)? = null
+  override var keyShortcutHandler: ((KeyEvent) -> Boolean)? = null
 
-  override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean {
     if (keyShortcutHandler?.invoke(event) == true) return true
+    // Consume BACK before the IME does. Otherwise the first press only hides the keyboard and the
+    // overlay stays up until a second press finishes this activity.
+    if (closeOverlayOnBackKey(event) { finish() }) return true
     return super.dispatchKeyEvent(event)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    closeOverlayOnPredictiveBack()
     enableEdgeToEdge()
 
     // Make window transparent
@@ -95,6 +101,19 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
   }
 
   /**
+   * Gesture back on API 33+ never becomes a [KeyEvent]. The IME registers at default priority to
+   * hide itself, so this overlay has to sit above that or the first swipe only drops the keyboard.
+   */
+  private fun closeOverlayOnPredictiveBack() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+    onBackInvokedDispatcher.registerOnBackInvokedCallback(
+      OnBackInvokedDispatcher.PRIORITY_OVERLAY
+    ) {
+      finish()
+    }
+  }
+
+  /**
    * Pushes whatever is behind this translucent window — the web page, the launcher — out of focus,
    * ramping the radius up so the backdrop settles along with the rest of the overlay instead of
    * snapping out of focus the instant the search opens.
@@ -134,4 +153,14 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
     const val EXTRA_CHROME_COLOR = "chrome_color"
     const val EXTRA_INITIAL_QUERY = "initial_query"
   }
+}
+
+/**
+ * Whether [event] is a back press that should close the search overlay rather than being handed to
+ * the IME. Down is consumed so the keyboard never sees it; the overlay closes on up.
+ */
+internal fun closeOverlayOnBackKey(event: KeyEvent, close: () -> Unit): Boolean {
+  if (event.keyCode != KeyEvent.KEYCODE_BACK) return false
+  if (event.action == KeyEvent.ACTION_UP) close()
+  return true
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -5,8 +5,10 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
+import android.widget.FrameLayout
 import android.window.OnBackInvokedDispatcher
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -98,6 +100,33 @@ class SearchActivity : ComponentActivity(), KeyShortcutHost {
         riseWithKeyboard = true,
       )
     }
+    interceptBackBeforeIme()
+  }
+
+  /**
+   * BACK is delivered to the IME before [dispatchKeyEvent], so intercepting there is too late: the
+   * first press only hides the keyboard. Walking the focused field's parents with
+   * [ViewGroup.dispatchKeyEventPreIme] is the path that still sees that press.
+   */
+  private fun interceptBackBeforeIme() {
+    val content = findViewById<ViewGroup>(android.R.id.content)
+    val child = content.getChildAt(0) ?: return
+    content.removeView(child)
+    val wrapper =
+      object : FrameLayout(this) {
+        override fun dispatchKeyEventPreIme(event: KeyEvent): Boolean {
+          if (closeOverlayOnBackKey(event) { finish() }) return true
+          return super.dispatchKeyEventPreIme(event)
+        }
+      }
+    wrapper.addView(
+      child,
+      FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+      ),
+    )
+    content.addView(wrapper)
   }
 
   /**

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -99,6 +99,7 @@ import com.searchlauncher.app.ui.components.SearchResultItem
 import com.searchlauncher.app.ui.components.ShortcutDialog
 import com.searchlauncher.app.ui.components.SnippetDialog
 import com.searchlauncher.app.ui.components.WallpaperBackground
+import com.searchlauncher.app.ui.components.homeWidgetsEnabled
 import com.searchlauncher.app.ui.components.loadPrivacyPolicyText
 import com.searchlauncher.app.ui.onboarding.OnboardingManager
 import com.searchlauncher.app.ui.onboarding.OnboardingStep
@@ -1052,7 +1053,12 @@ fun SearchScreen(
     closing?.let { BrowserTabTasks.close(context, it.id) }
   }
 
-  BackHandler(enabled = tabsOverviewOpen) { tabsOverviewOpen = false }
+  // The overlay is its own activity: back has to finish it, not merely hide the keyboard. The
+  // activity also intercepts BACK before the IME (see SearchActivity); this covers the case where
+  // the keys are already gone.
+  BackHandler(enabled = tabsOverviewOpen || riseWithKeyboard) {
+    if (tabsOverviewOpen) tabsOverviewOpen = false else onDismiss()
+  }
 
   // Pressing home while already on the launcher never stops the activity, so the lifecycle reset
   // below cannot catch it. The launcher bumps this instead whenever a home intent arrives, and
@@ -1467,18 +1473,20 @@ fun SearchScreen(
               leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
             )
           }
-          DropdownMenuItem(
-            text = { Text("Add Widget") },
-            onClick = {
-              showBackgroundMenu = false
-              onAddWidget()
-            },
-            // Not the plain Add the wallpaper entry uses — two identical plus icons in one menu
-            // would say nothing about which is which.
-            leadingIcon = { Icon(Icons.Default.Widgets, contentDescription = null) },
-          )
+          if (homeWidgetsEnabled(context)) {
+            DropdownMenuItem(
+              text = { Text("Add Widget") },
+              onClick = {
+                showBackgroundMenu = false
+                onAddWidget()
+              },
+              // Not the plain Add the wallpaper entry uses — two identical plus icons in one menu
+              // would say nothing about which is which.
+              leadingIcon = { Icon(Icons.Default.Widgets, contentDescription = null) },
+            )
+          }
           val widgets by app.widgetRepository.widgets.collectAsState(initial = emptyList())
-          if (showWidgetsSetting && widgets.isNotEmpty()) {
+          if (homeWidgetsEnabled(context) && showWidgetsSetting && widgets.isNotEmpty()) {
             DropdownMenuItem(
               text = { Text("Clear Widgets") },
               onClick = {

--- a/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
@@ -78,6 +78,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
+ * Widgets are hosted by [MainActivity]'s [android.appwidget.AppWidgetHost]. The browser's
+ * translucent search overlay is a different activity, so drawing them there produced "Widget
+ * unavailable" cards for every bound id.
+ */
+internal fun homeWidgetsEnabled(context: android.content.Context): Boolean = context is MainActivity
+
+/**
  * Page of the endlessly looping pager that shows [uriString], defaulting to the first image.
  *
  * The loop is centred on the middle of the index space so swiping backwards works from the start.
@@ -163,6 +170,9 @@ fun WallpaperBackground(
   savedUriResolved: Boolean = true,
 ) {
   val context = LocalContext.current
+  // The browser overlay is a different activity and has no AppWidgetHost. Drawing widgets there
+  // produced an error card for every bound id; they belong on the home screen only.
+  val widgetsEnabled = homeWidgetsEnabled(context)
 
   val contentModifier = Modifier.fillMaxSize().padding(bottom = bottomPadding)
 
@@ -206,11 +216,13 @@ fun WallpaperBackground(
                 // that was just being arranged. A second tap then toggles them as it always does.
                 activeWidgetId = -1
               } else {
-                val newState = !showWidgets
-                val scope = CoroutineScope(Dispatchers.IO)
-                scope.launch {
-                  context.dataStore.edit { preferences ->
-                    preferences[PreferencesKeys.SHOW_WIDGETS] = newState
+                if (widgetsEnabled) {
+                  val newState = !showWidgets
+                  val scope = CoroutineScope(Dispatchers.IO)
+                  scope.launch {
+                    context.dataStore.edit { preferences ->
+                      preferences[PreferencesKeys.SHOW_WIDGETS] = newState
+                    }
                   }
                 }
                 onTap()
@@ -267,7 +279,7 @@ fun WallpaperBackground(
       }
     }
 
-    if (widgets.isNotEmpty()) {
+    if (widgetsEnabled && widgets.isNotEmpty()) {
       AnimatedVisibility(visible = showWidgets, enter = fadeIn(), exit = fadeOut()) {
         val isAnyWidgetActive = activeWidgetId != -1
         if (isAnyWidgetActive) {

--- a/app/src/test/java/com/searchlauncher/app/ui/SearchActivityTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/SearchActivityTest.kt
@@ -1,0 +1,30 @@
+package com.searchlauncher.app.ui
+
+import android.view.KeyEvent
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchActivityTest {
+
+  @Test
+  fun backKeyClosesTheOverlayOnUp() {
+    var closed = false
+    val down = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK)
+    val up = KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK)
+
+    assertTrue(closeOverlayOnBackKey(down) { closed = true })
+    assertFalse(closed)
+    assertTrue(closeOverlayOnBackKey(up) { closed = true })
+    assertTrue(closed)
+  }
+
+  @Test
+  fun otherKeysAreLeftToTheWindow() {
+    var closed = false
+    val escape = KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ESCAPE)
+
+    assertFalse(closeOverlayOnBackKey(escape) { closed = true })
+    assertFalse(closed)
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/SearchActivityTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/SearchActivityTest.kt
@@ -4,7 +4,10 @@ import android.view.KeyEvent
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class SearchActivityTest {
 
   @Test

--- a/app/src/test/java/com/searchlauncher/app/ui/components/HomeWidgetsEnabledTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/HomeWidgetsEnabledTest.kt
@@ -1,0 +1,29 @@
+package com.searchlauncher.app.ui.components
+
+import android.app.Activity
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import com.searchlauncher.app.ui.MainActivity
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class HomeWidgetsEnabledTest {
+
+  @Test
+  fun homeScreenCanHostWidgets() {
+    assertTrue(homeWidgetsEnabled(mockk<MainActivity>(relaxed = true)))
+  }
+
+  @Test
+  fun overlayAndOtherActivitiesCannot() {
+    assertFalse(homeWidgetsEnabled(ApplicationProvider.getApplicationContext()))
+    assertFalse(homeWidgetsEnabled(mockk<Activity>(relaxed = true)))
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The in-browser search overlay treated the first back press as “hide the keyboard” and left the bar up, so a second press was needed to return to the page. It also tried to host home-screen widgets, which cannot be drawn outside `MainActivity` and showed “Widget unavailable” error cards.

## Changes
- Consume BACK before the IME (`dispatchKeyEventPreIme` wrapper) and register predictive back at overlay priority so one press finishes `SearchActivity`.
- `BackHandler` on the overlay still dismisses when the keyboard is already gone.
- Skip widget rendering (and the add/clear widget menu) unless the host is `MainActivity`.

## Testing
- Unit tests: `SearchActivityTest`, `HomeWidgetsEnabledTest`.
- Emulator: seeded a leftover widget id so the home screen shows “Widget unavailable”; the browser overlay does not. One Back press closes the overlay and keyboard together.

[Home screen still shows the leftover widget error card](https://cursor.com/agents/bc-c79e346b-a8d3-4087-9e75-83595ac0384f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_widget_unavailable.png)
[Browser search overlay with no widget error cards](https://cursor.com/agents/bc-c79e346b-a8d3-4087-9e75-83595ac0384f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser_search_overlay.png)
[browser_search_back_closes_overlay.mp4](https://cursor.com/agents/bc-c79e346b-a8d3-4087-9e75-83595ac0384f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser_search_back_closes_overlay.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c79e346b-a8d3-4087-9e75-83595ac0384f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c79e346b-a8d3-4087-9e75-83595ac0384f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

