### PR TITLE
Release 0.0.26

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 262
-    versionName = "0.0.24"
+    versionCode = 264
+    versionName = "0.0.26"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/fastlane/metadata/android/en-US/changelogs/263.txt
+++ b/fastlane/metadata/android/en-US/changelogs/263.txt
@@ -1,0 +1,1 @@
+Set as Default Browser in Settings now opens the system picker. A set favorites row count always uses that many rows, filled with recents. Recents run left to right, include open tabs with their favicons, and search shortcuts follow usage when you type a query.

--- a/fastlane/metadata/android/en-US/changelogs/264.txt
+++ b/fastlane/metadata/android/en-US/changelogs/264.txt
@@ -1,0 +1,1 @@
+Back in the in-app browser closes the search overlay in one press. Widgets stay on the home screen. While searching, the favorites bar stays one row. The keyboard appears with the search bar instead of leaving an empty well.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cuts **0.0.26** (`versionCode` 264), tagged `v0.0.26`.

Built on 0.0.25 plus the browser search overlay fix:
- Back closes the in-browser search overlay in one press (keyboard and overlay together)
- Home-screen widgets no longer render or error in that overlay

GitHub release (signed APK): https://github.com/ontola/searchlauncher/releases/tag/v0.0.26

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c79e346b-a8d3-4087-9e75-83595ac0384f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c79e346b-a8d3-4087-9e75-83595ac0384f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

