### PR TITLE
Stop asking for five Bluetooth permissions nothing can use

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,18 +26,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_SCAN"
-        android:usesPermissionFlags="neverForLocation"
-        tools:targetApi="31" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_CONNECT"
-        tools:targetApi="31" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADVERTISE"
-        tools:targetApi="31" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
@@ -49,7 +37,6 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
-    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false" />
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 


### PR DESCRIPTION
Removes `BLUETOOTH`, `BLUETOOTH_ADMIN`, `BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT` and `BLUETOOTH_ADVERTISE`, plus the `android.hardware.bluetooth` feature.

They exist for one branch in `BrowserDeviceAccess` that maps a WebView permission request to Web Bluetooth:

```kotlin
resource.contains("BLUETOOTH", ignoreCase = true) -> BrowserDeviceAccess.BLUETOOTH
```

`PermissionRequest` defines exactly four resource constants — audio capture, video capture, MIDI sysex, protected media — and Chromium's WebView does not implement Web Bluetooth, so the branch cannot fire. `BLUETOOTH_ADVERTISE` is not referenced even there.

Play requires a sensitive-permissions declaration, and `BLUETOOTH_SCAN` in particular is treated as location inference. On a launcher it invites scrutiny of the camera and location permissions the browser genuinely needs.

The unreachable branch is left in place — requesting an undeclared permission is denied rather than fatal, and its tests still pass. Storage and media permissions are left to #118.

`spotlessCheck` and the full test suite pass.