### PR TITLE
Release 0.0.27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 264
-    versionName = "0.0.26"
+    versionCode = 265
+    versionName = "0.0.27"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/fastlane/metadata/android/en-US/changelogs/265.txt
+++ b/fastlane/metadata/android/en-US/changelogs/265.txt
@@ -1,0 +1,1 @@
+No more photos or all-files permission just to show the wallpaper — the system wallpaper shows through. Widgets stay above a multi-row favorites bar instead of sliding under it. Unused Bluetooth permissions are gone.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps to **0.0.27** (`versionCode` 265) so a `v0.0.27` tag can ship the work already on main:

- No photos / all-files grant just to show the wallpaper
- Widgets stay above a multi-row favorites bar
- Unused Bluetooth permissions removed

Changelog is in `fastlane/metadata/android/en-US/changelogs/265.txt`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

