### PR TITLE
Bring the keyboard back after the system dismisses it

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -746,18 +746,28 @@ fun SearchScreen(
   val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
   val shouldShowKeyboard =
     rememberUpdatedState(isActive && !openingTab && !browserShowing && !inPip)
+  // The inset is watched as well as window focus. Back is not routed through this screen, so a
+  // system dismissal reaches us only as the IME inset going away — and window focus does not move
+  // when it does. Waiting on focus alone left one Back press with the keys gone for good, above the
+  // band the wallpaper reserves for them.
+  val imeInsets = WindowInsets.ime
+  val imeInsetDensity = LocalDensity.current
   LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip) {
     if (!shouldShowKeyboard.value) {
       Ime.hide(view)
       return@LaunchedEffect
     }
     runCatching { focusRequester.requestFocus() }
-    snapshotFlow { windowInfo.isWindowFocused }
-      .collect { focused ->
-        if (!focused || !shouldShowKeyboard.value) return@collect
+    snapshotFlow { windowInfo.isWindowFocused && imeInsets.getBottom(imeInsetDensity) <= 0 }
+      .collect { keyboardWanted ->
+        if (!keyboardWanted || !shouldShowKeyboard.value) return@collect
         var shows = 0
         var attempts = 0
-        while (windowInfo.isWindowFocused && shouldShowKeyboard.value) {
+        while (
+          windowInfo.isWindowFocused &&
+            shouldShowKeyboard.value &&
+            imeInsets.getBottom(imeInsetDensity) <= 0
+        ) {
           runCatching { focusRequester.requestFocus() }
           if (Ime.isVisible(view)) break
           // One ask, then one retry after a few frames if the editor was not ready. More than


### PR DESCRIPTION
Back is not routed through the search screen, so when the system dismisses the IME the only signal that reaches us is the inset going away. Window focus does not move, which is what the retry loop was waiting on — so one Back press left the keys gone for good, with the wallpaper still reserving the band they had occupied.

The loop now watches `WindowInsets.ime` alongside `isWindowFocused`, so a dismissal it did not ask for is something it can see and undo.

Picked up from uncommitted work left over from the `faster-keyboard` branch, applied cleanly onto current main.

**Checks**
- `spotlessCheck` and the full unit suite pass
- Installed on an emulator: keyboard up on launch, still up after Back and after Home, no crashes in logcat

Worth a look on a real device before merging — the emulator does not reproduce the stuck state the fix is for, so the smoke test shows no regression rather than confirming the fix.