### PR TITLE
Add option to lock the launcher to portrait

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -29,12 +29,19 @@ object Prefs {
   /**
    * Miscellaneous launcher state.
    *
-   * Note: [MIN_ICON_SIZE] mirrors the DataStore setting of the same name; it is kept here only as a
-   * synchronous boot cache so the first frame can size icons without waiting on DataStore.
+   * Note: [MIN_ICON_SIZE] and [LOCK_PORTRAIT] mirror DataStore settings of the same name; they are
+   * kept here only as synchronous boot caches so the first frame can size icons and lock
+   * orientation without waiting on DataStore.
    */
   object Launcher {
     const val FILE = "search_launcher_prefs"
     const val MIN_ICON_SIZE = "min_icon_size"
+    /**
+     * Mirrors the DataStore [com.searchlauncher.app.ui.PreferencesKeys.LOCK_PORTRAIT] setting so
+     * [com.searchlauncher.app.ui.MainActivity] can lock orientation on the first frame of a cold
+     * start, before the async DataStore read completes.
+     */
+    const val LOCK_PORTRAIT = "lock_portrait"
     const val OBSERVED_HISTORY_LIMIT = "observed_history_limit"
     const val LAST_REINDEX_TIMESTAMP = "last_reindex_timestamp"
     const val APPS_FINGERPRINT = "apps_fingerprint"

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -473,6 +473,13 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     queryState = savedInstanceState?.getString(KEY_ACTIVE_QUERY) ?: restoreRecentQuery()
     enableEdgeToEdge()
     Ime.applyWindowMode(window)
+    PortraitLock.apply(this, PortraitLock.cached(this))
+    lifecycleScope.launch {
+      PortraitLock.flow(this@MainActivity).distinctUntilChanged().collect { locked ->
+        PortraitLock.updateCache(this@MainActivity, locked)
+        PortraitLock.apply(this@MainActivity, locked)
+      }
+    }
 
     setContent {
       val themeColor =
@@ -538,6 +545,9 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
   ) {
     super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
     inPictureInPicture = isInPictureInPictureMode
+    if (!isInPictureInPictureMode) {
+      PortraitLock.apply(this, PortraitLock.cached(this))
+    }
   }
 
   override fun enterPipIfEligible(): Boolean {

--- a/app/src/main/java/com/searchlauncher/app/ui/PortraitLock.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/PortraitLock.kt
@@ -1,0 +1,53 @@
+package com.searchlauncher.app.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.pm.ActivityInfo
+import com.searchlauncher.app.data.Prefs
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Home-screen portrait lock.
+ *
+ * DataStore ([PreferencesKeys.LOCK_PORTRAIT]) is the source of truth, but the value is mirrored to
+ * a synchronous SharedPreferences cache ([Prefs.Launcher.LOCK_PORTRAIT]) so [MainActivity] can set
+ * [Activity.requestedOrientation] on a cold start before the async DataStore read completes.
+ * Without that cache the launcher would follow auto-rotate for a frame and then snap.
+ */
+object PortraitLock {
+
+  /** Source-of-truth flow from DataStore. Off by default. */
+  fun flow(context: Context): Flow<Boolean> =
+    context.dataStore.data.map { it[PreferencesKeys.LOCK_PORTRAIT] ?: false }
+
+  /** Synchronously readable boot cache, used before [flow] emits. */
+  fun cached(context: Context): Boolean =
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .getBoolean(Prefs.Launcher.LOCK_PORTRAIT, false)
+
+  /** Refreshes the boot cache so the next cold start can lock orientation without waiting. */
+  fun updateCache(context: Context, locked: Boolean) {
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .putBoolean(Prefs.Launcher.LOCK_PORTRAIT, locked)
+      .apply()
+  }
+
+  /**
+   * Sets [activity] to portrait when [locked], or back to the system default when not. Skipped
+   * while the activity is in picture-in-picture, where a requested-orientation change can kick the
+   * window out of PiP.
+   */
+  fun apply(activity: Activity, locked: Boolean) {
+    if (activity.isInPictureInPictureMode) return
+    val orientation =
+      if (locked) ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+      else ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+    if (activity.requestedOrientation != orientation) {
+      activity.requestedOrientation = orientation
+    }
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
@@ -34,6 +34,12 @@ object PreferencesKeys {
   val SEARCH_SHORTCUTS_ENABLED = booleanPreferencesKey("search_shortcuts_enabled")
 
   /**
+   * When true, the home screen stays in portrait even if the device has auto-rotate on. Off by
+   * default so the launcher follows the system orientation like any other activity.
+   */
+  val LOCK_PORTRAIT = booleanPreferencesKey("lock_portrait")
+
+  /**
    * Whether the keyboard may autocorrect what is typed into the search bar. Off by default: a query
    * is usually a name, a command or a URL fragment, and having it silently rewritten into a
    * dictionary word is worse than a typo the user can see.

--- a/app/src/main/java/com/searchlauncher/app/ui/ThemeSettingsCard.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ThemeSettingsCard.kt
@@ -74,8 +74,39 @@ fun ThemeSettingsCard() {
   var showColorPickerDialog by remember { mutableStateOf(false) }
   var showImageColorPickerDialog by remember { mutableStateOf(false) }
 
+  val lockPortrait by
+    remember { PortraitLock.flow(context) }.collectAsState(initial = PortraitLock.cached(context))
+
   Card(modifier = Modifier.fillMaxWidth()) {
     Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+          Text(text = "Lock to portrait", style = MaterialTheme.typography.titleMedium)
+          Text(
+            text = "Keep the home screen in portrait even when auto-rotate is on.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        Switch(
+          checked = lockPortrait,
+          onCheckedChange = { checked ->
+            scope.launch {
+              context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.LOCK_PORTRAIT] = checked
+              }
+              PortraitLock.updateCache(context, checked)
+            }
+          },
+        )
+      }
+
+      HorizontalDivider()
+
       // OLED Toggle (only if dark mode is enabled or system is dark)
       Row(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/test/java/com/searchlauncher/app/ui/PortraitLockTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/PortraitLockTest.kt
@@ -1,0 +1,60 @@
+package com.searchlauncher.app.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.pm.ActivityInfo
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.data.Prefs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PortraitLockTest {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Before
+  fun clearCache() {
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .remove(Prefs.Launcher.LOCK_PORTRAIT)
+      .commit()
+  }
+
+  @Test
+  fun cached_defaultsToUnlocked() {
+    assertFalse(PortraitLock.cached(context))
+  }
+
+  @Test
+  fun updateCache_roundTrips() {
+    PortraitLock.updateCache(context, true)
+    assertTrue(PortraitLock.cached(context))
+    PortraitLock.updateCache(context, false)
+    assertFalse(PortraitLock.cached(context))
+  }
+
+  @Test
+  fun apply_locksToPortrait() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    PortraitLock.apply(activity, locked = true)
+    assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, activity.requestedOrientation)
+  }
+
+  @Test
+  fun apply_clearsToSystemDefaultWhenUnlocked() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    PortraitLock.apply(activity, locked = true)
+    PortraitLock.apply(activity, locked = false)
+    assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #123.

Adds a **Lock to portrait** toggle in Settings so the home screen stays in portrait even when the device has auto-rotate enabled.

- Preference is stored in DataStore (`lock_portrait`, off by default) and mirrored to a SharedPreferences boot cache so `MainActivity` can set `requestedOrientation` on the first frame of a cold start.
- Toggling the switch applies immediately. The browser is left free to rotate.
- Orientation is not changed while the launcher is in picture-in-picture, then re-applied when leaving PiP.

### Verification
- `./gradlew test` (debug + release unit tests) passed, including `PortraitLockTest`.
- On the API 30 AOSP emulator: enabling the toggle set `SCREEN_ORIENTATION_PORTRAIT`; requesting landscape (`wm set-user-rotation lock 1`) left the display at 1080×2400. Turning the toggle off allowed rotation to 2400×1080.

[Settings showing Lock to portrait toggle](https://cursor.com/agents/bc-c7f1f40a-c78a-404d-b591-3f890e1a38f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_lock_to_portrait_toggle.png)
[Lock on, display stays portrait after a landscape rotation request](https://cursor.com/agents/bc-c7f1f40a-c78a-404d-b591-3f890e1a38f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocked_stays_portrait_when_rotated.png)
[Lock off, settings follows landscape](https://cursor.com/agents/bc-c7f1f40a-c78a-404d-b591-3f890e1a38f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funlocked_follows_landscape_rotation.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f1f40a-c78a-404d-b591-3f890e1a38f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f1f40a-c78a-404d-b591-3f890e1a38f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

