### PR TITLE
Reindex snippets after Settings add, edit, and delete

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -1753,15 +1753,37 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   // indexContacts - Removed
 
+  /** Persists a snippet then rebuilds the snippets namespace so search sees it immediately. */
+  suspend fun saveSnippet(alias: String, content: String, previousAlias: String? = null) {
+    val app = context.applicationContext as SearchLauncherApp
+    if (previousAlias != null) {
+      app.snippetsRepository.updateItem(previousAlias, alias, content)
+    } else {
+      app.snippetsRepository.addItem(alias, content)
+    }
+    indexSnippets()
+  }
+
+  /** Removes a snippet then rebuilds the snippets namespace so search drops it immediately. */
+  suspend fun deleteSnippet(alias: String) {
+    val app = context.applicationContext as SearchLauncherApp
+    app.snippetsRepository.deleteItem(alias)
+    indexSnippets()
+  }
+
   suspend fun indexSnippets() =
     withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
-      val session = appSearchSession ?: return@withContext
+      val docs = snippetIndexer.buildDocuments()
 
       try {
-        val docs = snippetIndexer.buildDocuments()
-        putDocuments(session, docs)
-        removeMissingDocuments(session, "snippets", docs.map { it.id }.toSet())
+        val session = appSearchSession
+        if (session != null) {
+          putDocuments(session, docs)
+          removeMissingDocuments(session, "snippets", docs.map { it.id }.toSet())
+        }
+        // Keep the in-memory snapshot in sync even if AppSearch is not ready yet, so a snippet
+        // added from Settings is searchable without waiting for a full reindex or restart.
         replaceCollection("snippets", docs)
         android.util.Log.d("SearchRepository", "Indexed ${docs.size} snippets")
       } catch (e: Exception) {

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -2243,13 +2243,9 @@ fun SearchScreen(
       isEditMode = snippetEditMode,
       onDismiss = { showSnippetDialog = false },
       onConfirm = { alias, content ->
+        val previousAlias = snippetItemToEdit?.alias.takeIf { snippetEditMode }
         scope.launch(Dispatchers.IO) {
-          if (snippetEditMode && snippetItemToEdit != null) {
-            app.snippetsRepository.updateItem(snippetItemToEdit!!.alias, alias, content)
-          } else {
-            app.snippetsRepository.addItem(alias, content)
-          }
-          app.searchRepository.indexSnippets()
+          app.searchRepository.saveSnippet(alias, content, previousAlias)
         }
         showSnippetDialog = false
       },

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -90,6 +90,7 @@ import com.searchlauncher.app.ui.components.PrivacyPolicyDialog
 import com.searchlauncher.app.ui.components.loadPrivacyPolicyText
 import com.searchlauncher.app.ui.components.shouldShowFavoritesIconSizeSetting
 import com.searchlauncher.app.util.CustomActionHandler
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -612,7 +613,9 @@ private fun SnippetsCard() {
                 )
               }
               IconButton(
-                onClick = { scope.launch { app.snippetsRepository.deleteItem(item.alias) } }
+                onClick = {
+                  scope.launch(Dispatchers.IO) { app.searchRepository.deleteSnippet(item.alias) }
+                }
               ) {
                 Icon(
                   imageVector = Icons.Default.Close,
@@ -641,14 +644,11 @@ private fun SnippetsCard() {
       isEditMode = editingItem != null,
       onDismiss = { showDialog = false },
       onConfirm = { alias, content ->
-        scope.launch {
-          if (editingItem != null) {
-            app.snippetsRepository.updateItem(editingItem!!.alias, alias, content)
-          } else {
-            app.snippetsRepository.addItem(alias, content)
-          }
-          showDialog = false
+        val previousAlias = editingItem?.alias
+        scope.launch(Dispatchers.IO) {
+          app.searchRepository.saveSnippet(alias, content, previousAlias)
         }
+        showDialog = false
       },
     )
   }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/ResultContextMenu.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/ResultContextMenu.kt
@@ -171,7 +171,7 @@ internal fun ResultContextMenuItems(
       text = { Text("Delete") },
       onClick = {
         val app = context.applicationContext as SearchLauncherApp
-        CoroutineScope(Dispatchers.IO).launch { app.snippetsRepository.deleteItem(result.alias) }
+        CoroutineScope(Dispatchers.IO).launch { app.searchRepository.deleteSnippet(result.alias) }
         onCloseMenu()
       },
       leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -32,6 +32,7 @@ class SearchRepositoryTest {
     }
     File(context.filesDir, "usage_stats.json").delete()
     File(context.filesDir, "query_usage_stats.json").delete()
+    (context.applicationContext as SearchLauncherApp).snippetsRepository.clearAll()
   }
 
   @Test
@@ -791,5 +792,50 @@ class SearchRepositoryTest {
         documentByNamespaceAndId = emptyMap(),
       )
     assertTrue(placeHits.any { it.first.doc.namespace == "calendar" && it.first.doc.id == "9/1" })
+  }
+
+  @Test
+  fun `saveSnippet makes a new snippet searchable without a full reindex`() = runBlocking {
+    repository.saveSnippet("first_test", "test")
+
+    val results =
+      repository.searchApps("first_test", limit = 5, includeSuggestions = false).getOrThrow()
+    val match = results.filterIsInstance<SearchResult.Snippet>().first()
+    assertEquals("first_test", match.alias)
+    assertEquals("test", match.content)
+  }
+
+  @Test
+  fun `saveSnippet updates an existing snippet in search immediately`() = runBlocking {
+    repository.saveSnippet("first_test", "old content")
+    repository.saveSnippet("first_test_renamed", "new content", previousAlias = "first_test")
+
+    val oldAliasResults =
+      repository.searchApps("first_test", limit = 5, includeSuggestions = false).getOrThrow()
+    assertTrue(
+      "The old alias should no longer be a snippet hit",
+      oldAliasResults.filterIsInstance<SearchResult.Snippet>().none { it.alias == "first_test" },
+    )
+
+    val renamedResults =
+      repository
+        .searchApps("first_test_renamed", limit = 5, includeSuggestions = false)
+        .getOrThrow()
+    val match = renamedResults.filterIsInstance<SearchResult.Snippet>().first()
+    assertEquals("first_test_renamed", match.alias)
+    assertEquals("new content", match.content)
+  }
+
+  @Test
+  fun `deleteSnippet removes it from search immediately`() = runBlocking {
+    repository.saveSnippet("first_test", "test")
+    repository.deleteSnippet("first_test")
+
+    val results =
+      repository.searchApps("first_test", limit = 5, includeSuggestions = false).getOrThrow()
+    assertTrue(
+      "Deleted snippets must leave the live index, not wait for the next restart",
+      results.filterIsInstance<SearchResult.Snippet>().isEmpty(),
+    )
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/ontola/searchlauncher/issues/124

Snippets added from Settings showed up in the Snippets list but not in search until the launcher restarted. The search-bar dialog already called `indexSnippets()` after save; the Settings dialog only wrote SharedPreferences. Deleting from Settings (and from a result’s context menu) had the same gap: the list changed, the index did not.

**What changed**
- Added `SearchRepository.saveSnippet()` / `deleteSnippet()` so persist + reindex always happen together.
- Settings add/edit/delete, the search-bar snippet dialog, and the result context-menu delete all use those methods.
- `indexSnippets()` still updates the in-memory snapshot even if AppSearch is not ready yet, so search does not wait for a full reindex or restart.

**How to verify**
1. Settings → Snippets → Add. Alias `first_test`, content `test`.
2. Go back to the home screen and search `first_test`. The snippet should appear without restarting.
3. Delete the snippet from Settings, then search again. It should be gone.

**Testing**
- Unit tests: `saveSnippet` makes a snippet searchable immediately, updates rename it in the index, and `deleteSnippet` removes it. Full `./gradlew test` passed.
- Emulator: added `issue124` / `hello` from Settings, searched from home without restarting; the snippet was the highlighted result.

[Snippet added from Settings is immediately searchable](https://cursor.com/agents/bc-66f56e66-1ffe-4010-8392-f58e0c06ff38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue124_snippet_in_search.png)
[settings_snippet_searchable_without_restart.mp4](https://cursor.com/agents/bc-66f56e66-1ffe-4010-8392-f58e0c06ff38/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_snippet_searchable_without_restart.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66f56e66-1ffe-4010-8392-f58e0c06ff38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66f56e66-1ffe-4010-8392-f58e0c06ff38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

