### PR TITLE
Prefer the YouTube app for custom search

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/SearchShortcutRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchShortcutRepository.kt
@@ -73,7 +73,7 @@ class SearchShortcutRepository(context: Context) {
     // Merge in any new default shortcuts that are missing from persisted items
     val defaults = DefaultShortcuts.searchShortcuts
     val missingDefaults = defaults.filter { default -> persistedItems.none { it.id == default.id } }
-    val migrated = migrateSupersededTemplates(persistedItems)
+    val migrated = migratePersistedShortcuts(persistedItems)
 
     if (missingDefaults.isNotEmpty() || migrated != persistedItems) {
       saveItems(migrated + missingDefaults)
@@ -84,17 +84,35 @@ class SearchShortcutRepository(context: Context) {
   }
 
   /**
-   * Rewrites shortcuts whose default URL template was replaced by a better one. Matching on the
-   * superseded template means a shortcut the user edited themselves is left alone — only one still
-   * carrying the old default is moved forward. New defaults arrive through [missingDefaults]
-   * instead; this is for ids that already exist and would otherwise keep the stale template
-   * forever, since nothing short of "Reset Defaults" rewrites them.
+   * Rewrites stock shortcuts that a previous version persisted, without touching ones the user
+   * edited themselves.
+   *
+   * URL templates are matched against [SUPERSEDED_TEMPLATES] so only a shortcut still carrying the
+   * old default is moved forward. Package names are filled in when the default now names an app
+   * (YouTube → `com.google.android.youtube`) and this copy still has the stock URL with no package
+   * of its own — that is how existing installs pick up "open in the app if installed" without a
+   * Reset Defaults.
+   *
+   * New ids arrive through [missingDefaults] instead; this is for ids that already exist and would
+   * otherwise keep the stale data forever.
    */
-  private fun migrateSupersededTemplates(items: List<SearchShortcut>): List<SearchShortcut> =
-    items.map { item ->
+  private fun migratePersistedShortcuts(items: List<SearchShortcut>): List<SearchShortcut> {
+    val defaultsById = DefaultShortcuts.searchShortcuts.associateBy { it.id }
+    return items.map { item ->
+      var updated = item
       val replacement = SUPERSEDED_TEMPLATES[item.id to item.urlTemplate]
-      if (replacement == null) item else item.copy(urlTemplate = replacement)
+      if (replacement != null) updated = updated.copy(urlTemplate = replacement)
+      val default = defaultsById[item.id]
+      if (
+        updated.packageName == null &&
+          default?.packageName != null &&
+          updated.urlTemplate == default.urlTemplate
+      ) {
+        updated = updated.copy(packageName = default.packageName)
+      }
+      updated
     }
+  }
 
   fun resetToDefaults() {
     val defaults = DefaultShortcuts.searchShortcuts

--- a/app/src/main/java/com/searchlauncher/app/data/ShortcutLaunch.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ShortcutLaunch.kt
@@ -1,0 +1,79 @@
+package com.searchlauncher.app.data
+
+import android.app.SearchManager
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+
+/**
+ * Opens a search-shortcut URL in a specific app when that app is installed and can handle it.
+ *
+ * Web templates ([ShortcutAvailability.isWebTemplate]) always have a browser fallback — the
+ * launcher carries its own — so a missing app must not hide the shortcut. Launch is the other half:
+ * if the user *does* have the app (YouTube for `youtube.com/results`, …), send the query there
+ * instead of loading the site in the in-app browser.
+ */
+object ShortcutLaunch {
+  /**
+   * An intent that delivers [url] to [packageName], or null if that app is not a viable target and
+   * the caller should fall back to the in-app browser (http/https) or a generic view intent.
+   *
+   * [query] is the unencoded search text, used only if the app does not claim the URL as an app
+   * link and instead exposes [Intent.ACTION_SEARCH].
+   */
+  fun preferredAppIntent(
+    packageManager: PackageManager,
+    url: String,
+    packageName: String?,
+    query: String? = null,
+  ): Intent? {
+    if (!isPreferredAppPackage(packageName)) return null
+    val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return null
+    if (uri.scheme != "http" && uri.scheme != "https") return null
+
+    val viewIntent =
+      Intent(Intent.ACTION_VIEW, uri)
+        .setPackage(packageName)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    if (packageManager.resolveActivity(viewIntent, 0) != null) return viewIntent
+
+    val searchQuery =
+      query?.takeIf { it.isNotBlank() }
+        ?: uri.getQueryParameter("search_query")
+        ?: uri.getQueryParameter("q")
+    if (searchQuery.isNullOrBlank()) return null
+
+    val searchIntent =
+      Intent(Intent.ACTION_SEARCH)
+        .setPackage(packageName)
+        .putExtra(SearchManager.QUERY, searchQuery)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return searchIntent.takeIf { packageManager.resolveActivity(it, 0) != null }
+  }
+
+  /**
+   * Same as [preferredAppIntent], but only for content results that came from a search shortcut.
+   * Bookmarks and other web hits use placeholder packages such as Chrome and must stay in the
+   * in-app browser.
+   */
+  fun preferredAppIntentForContent(
+    packageManager: PackageManager,
+    result: SearchResult.Content,
+    query: String = "",
+  ): Intent? {
+    if (result.namespace != SearchOptions.NAMESPACE) return null
+    val deepLink = result.deepLink ?: return null
+    return preferredAppIntent(packageManager, deepLink, result.packageName, query)
+  }
+
+  /**
+   * Real app ids look like `com.google.android.youtube`. Placeholders used elsewhere — `android`,
+   * MIME types, empty — must not pin the intent, or the browser fallback never runs.
+   */
+  fun isPreferredAppPackage(packageName: String?): Boolean {
+    if (packageName.isNullOrBlank()) return false
+    if (packageName == "android") return false
+    if ('/' in packageName) return false
+    return '.' in packageName
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/Shortcuts.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Shortcuts.kt
@@ -341,6 +341,7 @@ object DefaultShortcuts {
         alias = "y",
         urlTemplate = "https://www.youtube.com/results?search_query=%s",
         description = "YouTube Search",
+        packageName = "com.google.android.youtube",
         suggestionUrl =
           "http://suggestqueries.google.com/complete/search?client=firefox&ds=yt&q=%s",
         color = 0xFFFF0000,

--- a/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.widget.Toast
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.ShortcutLaunch
 import com.searchlauncher.app.ui.browser.BrowserActivity
 import com.searchlauncher.app.ui.browser.BrowserTabStore
 import com.searchlauncher.app.ui.browser.BrowserTabTasks
@@ -175,6 +176,16 @@ class ResultLauncher(
         val mime = result.packageName.takeIf { it.contains('/') }
         if (mime != null && intent.type == null) {
           intent.setDataAndType(uri, mime)
+        }
+      }
+      val appIntent =
+        ShortcutLaunch.preferredAppIntentForContent(context.packageManager, result, query)
+      if (appIntent != null) {
+        try {
+          context.startActivity(appIntent)
+          return
+        } catch (_: Exception) {
+          // App was removed or disabled between resolve and start; use the browser below.
         }
       }
       launchIntent(intent, query)

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -74,6 +74,7 @@ import com.searchlauncher.app.data.SearchOptions
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.SearchShortcut
+import com.searchlauncher.app.data.ShortcutLaunch
 import com.searchlauncher.app.data.applyHistoryLimit
 import com.searchlauncher.app.data.favoriteKey
 import com.searchlauncher.app.data.isFavoritable
@@ -2383,14 +2384,40 @@ private fun launchShortcutSearch(
 ) {
   try {
     val url = shortcut.urlForQuery(query)
-    // Not every shortcut template is a web URL — market:, spotify: and geo: ones name an app, and
-    // the WebView can only answer those with ERR_UNKNOWN_URL_SCHEME.
-    if (url.startsWith("http://") || url.startsWith("https://")) {
-      openBrowser(context, url, privateWebResults, openInBrowser)
-    } else {
-      context.startActivity(
-        Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      )
+    // Web templates are loaded in the in-app browser so they keep working with no extra app.
+    // When the shortcut names one (YouTube, …) and that app can handle the URL, prefer it —
+    // private browsing stays in the private browser, since the app would not be private.
+    val openedInApp =
+      !privateWebResults &&
+        run {
+          val appIntent =
+            ShortcutLaunch.preferredAppIntent(
+              context.packageManager,
+              url,
+              shortcut.packageName,
+              query,
+            )
+          if (appIntent != null) {
+            try {
+              context.startActivity(appIntent)
+              true
+            } catch (_: Exception) {
+              false
+            }
+          } else {
+            false
+          }
+        }
+    if (!openedInApp) {
+      // Not every shortcut template is a web URL — market:, spotify: and geo: ones name an app,
+      // and the WebView can only answer those with ERR_UNKNOWN_URL_SCHEME.
+      if (url.startsWith("http://") || url.startsWith("https://")) {
+        openBrowser(context, url, privateWebResults, openInBrowser)
+      } else {
+        context.startActivity(
+          Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+      }
     }
     if (!privateWebResults) {
       searchRepository.reportUsageAsync(result.namespace, result.id, query, wasFirstResult)

--- a/app/src/test/java/com/searchlauncher/app/data/SearchShortcutRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchShortcutRepositoryTest.kt
@@ -103,4 +103,46 @@ class SearchShortcutRepositoryTest {
     assertEquals(DefaultShortcuts.searchShortcuts.map { it.id }.toSet(), ids.toSet())
     assertEquals(ids.size, ids.distinct().size)
   }
+
+  @Test
+  fun `a persisted youtube without a package is pointed at the youtube app`() {
+    persist(
+      SearchShortcut(
+        "youtube",
+        "y",
+        "https://www.youtube.com/results?search_query=%s",
+        "YouTube Search",
+      )
+    )
+
+    val youtube = SearchShortcutRepository(context).items.value.first { it.id == "youtube" }
+    assertEquals("com.google.android.youtube", youtube.packageName)
+    assertEquals("https://www.youtube.com/results?search_query=%s", youtube.urlTemplate)
+  }
+
+  @Test
+  fun `a youtube the user pointed at a different url is left without a package`() {
+    val custom = "https://www.youtube.com/results?search_query=%s&sp=EgIQAQ%253D%253D"
+    persist(SearchShortcut("youtube", "y", custom, "YouTube Search"))
+
+    val youtube = SearchShortcutRepository(context).items.value.first { it.id == "youtube" }
+    assertEquals(custom, youtube.urlTemplate)
+    assertEquals(null, youtube.packageName)
+  }
+
+  @Test
+  fun `a user's youtube alias is kept while the package is filled in`() {
+    persist(
+      SearchShortcut(
+        "youtube",
+        "yt",
+        "https://www.youtube.com/results?search_query=%s",
+        "YouTube Search",
+      )
+    )
+
+    val youtube = SearchShortcutRepository(context).items.value.first { it.id == "youtube" }
+    assertEquals("yt", youtube.alias)
+    assertEquals("com.google.android.youtube", youtube.packageName)
+  }
 }

--- a/app/src/test/java/com/searchlauncher/app/data/ShortcutLaunchTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/ShortcutLaunchTest.kt
@@ -1,0 +1,170 @@
+package com.searchlauncher.app.data
+
+import android.app.SearchManager
+import android.content.Context
+import android.content.Intent
+import android.graphics.drawable.ColorDrawable
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class ShortcutLaunchTest {
+  private lateinit var context: Context
+
+  private val youtubeUrl = "https://www.youtube.com/results?search_query=cats"
+  private val youtubePackage = "com.google.android.youtube"
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+  }
+
+  private fun installViewHandler(url: String, packageName: String) {
+    val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)).setPackage(packageName)
+    shadowOf(context.packageManager)
+      .addResolveInfoForIntent(intent, android.content.pm.ResolveInfo())
+  }
+
+  private fun installSearchHandler(packageName: String) {
+    val intent = Intent(Intent.ACTION_SEARCH).setPackage(packageName)
+    shadowOf(context.packageManager)
+      .addResolveInfoForIntent(intent, android.content.pm.ResolveInfo())
+  }
+
+  @Test
+  fun `youtube default keeps the website template so it stays available without the app`() {
+    val youtube = DefaultShortcuts.searchShortcuts.first { it.id == "youtube" }
+
+    assertEquals("https://www.youtube.com/results?search_query=%s", youtube.urlTemplate)
+    assertEquals(youtubePackage, youtube.packageName)
+    assertTrue(ShortcutAvailability.isWebTemplate(youtube.urlTemplate))
+    assertTrue(ShortcutAvailability.isAvailable(context.packageManager, youtube))
+  }
+
+  @Test
+  fun `no preferred intent when the app is not installed`() {
+    assertNull(
+      ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, youtubePackage, "cats")
+    )
+  }
+
+  @Test
+  fun `view intent is pinned to the app when it handles the url`() {
+    installViewHandler(youtubeUrl, youtubePackage)
+
+    val intent =
+      ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, youtubePackage, "cats")
+
+    assertNotNull(intent)
+    assertEquals(Intent.ACTION_VIEW, intent!!.action)
+    assertEquals(youtubePackage, intent.`package`)
+    assertEquals(youtubeUrl, intent.data.toString())
+  }
+
+  @Test
+  fun `search intent is used when the app does not claim the url`() {
+    installSearchHandler(youtubePackage)
+
+    val intent =
+      ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, youtubePackage, "cats")
+
+    assertNotNull(intent)
+    assertEquals(Intent.ACTION_SEARCH, intent!!.action)
+    assertEquals(youtubePackage, intent.`package`)
+    assertEquals("cats", intent.getStringExtra(SearchManager.QUERY))
+  }
+
+  @Test
+  fun `search intent falls back to the url query parameter`() {
+    installSearchHandler(youtubePackage)
+
+    val intent =
+      ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, youtubePackage)
+
+    assertEquals("cats", intent!!.getStringExtra(SearchManager.QUERY))
+  }
+
+  @Test
+  fun `placeholder packages do not pin the intent`() {
+    installViewHandler(youtubeUrl, "android")
+
+    assertNull(ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, "android"))
+    assertNull(ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, null))
+    assertNull(
+      ShortcutLaunch.preferredAppIntent(context.packageManager, youtubeUrl, "application/pdf")
+    )
+  }
+
+  @Test
+  fun `non web urls are left to the generic launch path`() {
+    val spotify = "spotify:search:cats"
+    assertNull(
+      ShortcutLaunch.preferredAppIntent(
+        context.packageManager,
+        spotify,
+        "com.spotify.music",
+        "cats",
+      )
+    )
+  }
+
+  @Test
+  fun `content from a search shortcut prefers the app`() {
+    installViewHandler(youtubeUrl, youtubePackage)
+    val result =
+      SearchResult.Content(
+        id = "shortcut_y",
+        namespace = SearchOptions.NAMESPACE,
+        title = "YouTube Search: cats",
+        subtitle = "Search Shortcut",
+        icon = ColorDrawable(0),
+        packageName = youtubePackage,
+        deepLink = youtubeUrl,
+      )
+
+    val intent = ShortcutLaunch.preferredAppIntentForContent(context.packageManager, result, "cats")
+
+    assertEquals(youtubePackage, intent!!.`package`)
+    assertEquals(Intent.ACTION_VIEW, intent.action)
+  }
+
+  @Test
+  fun `bookmarks stay in the browser even if chrome is named`() {
+    val chrome = "com.android.chrome"
+    val page = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    installViewHandler(page, chrome)
+    val bookmark =
+      SearchResult.Content(
+        id = "bookmark",
+        namespace = "web_saved",
+        title = "A video",
+        subtitle = "Bookmark",
+        icon = ColorDrawable(0),
+        packageName = chrome,
+        deepLink = page,
+      )
+
+    assertNull(ShortcutLaunch.preferredAppIntentForContent(context.packageManager, bookmark))
+  }
+
+  @Test
+  fun `isPreferredAppPackage rejects placeholders`() {
+    assertTrue(ShortcutLaunch.isPreferredAppPackage(youtubePackage))
+    assertFalse(ShortcutLaunch.isPreferredAppPackage("android"))
+    assertFalse(ShortcutLaunch.isPreferredAppPackage(null))
+    assertFalse(ShortcutLaunch.isPreferredAppPackage(""))
+    assertFalse(ShortcutLaunch.isPreferredAppPackage("application/pdf"))
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
YouTube custom search (`y cats`) always opened youtube.com in the in-app browser, even when the YouTube app was installed.

This keeps the website URL as the shortcut template so search still works without the app, and pins the shortcut to `com.google.android.youtube` so an installed YouTube app gets the query instead.

**Behavior**
- YouTube app installed: search opens in the app (`ACTION_VIEW` on the results URL, or `ACTION_SEARCH` if the app does not claim the URL).
- YouTube app missing: same as before — the site loads in the in-app browser.
- Private browsing still uses the private browser, since the YouTube app would not be private.
- Existing installs with the stock YouTube URL pick up the package name automatically; a user-edited YouTube URL is left alone.

**Tests**
- `ShortcutLaunch` unit tests for app-present, app-missing, `ACTION_SEARCH` fallback, and bookmark isolation (10 tests).
- Repository migration tests for persisted YouTube shortcuts.
- Full `./gradlew test` passed.
- Emulator: `y cats` opens a YouTube handler when one is installed, and youtube.com in the in-app browser when it is not.

[YouTube Search: cats result in SearchLauncher](https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_search_cats_result.png)
[YouTube app opened with query cats](https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_app_opened_cats.png)
[Site fallback in the in-app browser](https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_site_fallback_loaded.png)
[youtube_alias_search_opens_app.mp4](https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_alias_search_opens_app.mp4)
[youtube_search_falls_back_to_site.mp4](https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_search_falls_back_to_site.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d8e28b7-3261-475a-a536-37d61fcdac56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d8e28b7-3261-475a-a536-37d61fcdac56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

