### PR TITLE
Release 0.0.29

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 266
-    versionName = "0.0.28"
+    versionCode = 267
+    versionName = "0.0.29"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/fastlane/metadata/android/en-US/changelogs/267.txt
+++ b/fastlane/metadata/android/en-US/changelogs/267.txt
@@ -1,0 +1,1 @@
+YouTube search opens the YouTube app when it's installed, and falls back to youtube.com in the browser when it isn't.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps to **0.0.29** (`versionCode` 267) and tags the work already on main:

- YouTube search opens the YouTube app when it's installed, and falls back to youtube.com in the browser when it isn't

Changelog is in `fastlane/metadata/android/en-US/changelogs/267.txt`.

Tag `v0.0.29` is pushed. GitHub release: https://github.com/ontola/searchlauncher/releases/tag/v0.0.29
Play internal upload succeeded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e4bad5-86bf-4ac9-8419-a9c0c4b8872d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

