### PR TITLE
Add contextual home keyboard and release v0.0.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android app that lets you search everything on your phone and on the web, and op
 
 ## Features
 
-- **Direct keyboard access** - Your homescreen now has a keyboard!
+- **Built-in home keyboard** - Home search opens with its own QWERTY keyboard, without waiting for the system keyboard animation. Includes numbers/symbols, hold-and-release symbols (hinted in the upper corner of each key; slide while holding to choose accents or alternatives), caps lock (hold Shift), and repeating backspace. Turn off **Settings → Search → Use built-in keyboard** for your preferred keyboard, swipe typing, or other languages. Browser fields and dialogs use your system keyboard.
 - **Search everything on your phone** - Apps, their shortcuts, device settings, downloads, upcoming calendar events, sorted smartly by usage.
 - **Search everything on the web** - Youtube, google, bing, maps, spotify... Or add your own custom shortcuts!
 - **Built-in ad-free browser** - Opens web results in-app, blocking ads and trackers by default. Browse privately in an isolated window. File uploads, picture-in-picture video, and hardware-keyboard shortcuts are included.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 266
-    versionName = "0.0.28"
+    versionCode = 267
+    versionName = "0.0.29"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/app/src/androidTest/java/com/searchlauncher/app/ui/components/HomeSearchKeyboardTest.kt
+++ b/app/src/androidTest/java/com/searchlauncher/app/ui/components/HomeSearchKeyboardTest.kt
@@ -1,0 +1,224 @@
+package com.searchlauncher.app.ui.components
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.moveBy
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HomeSearchKeyboardTest {
+  @get:Rule val compose = createComposeRule()
+
+  private fun holdKey(key: String) {
+    compose.onNodeWithText(key).performTouchInput {
+      down(center)
+      advanceEventTime(700)
+      moveBy(Offset.Zero)
+    }
+    // Keep the pointer down while Android's long-press timeout expires.
+    android.os.SystemClock.sleep(600)
+    compose.waitForIdle()
+  }
+
+  @Test
+  fun extraCharacterCommitsAfter250msHold() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    compose.onNodeWithText("q").performTouchInput { longClick(durationMillis = 300) }
+    compose.runOnIdle { assertEquals("1", text) }
+    compose.onNodeWithContentDescription("Alternative 1").assertDoesNotExist()
+  }
+
+  @Test
+  fun touchTapTypesLetterAndCancelledHoldTypesNothing() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    compose.onNodeWithText("q").performTouchInput { click() }
+    compose.runOnIdle { assertEquals("q", text) }
+    holdKey("q")
+    compose.onNodeWithText("q").performTouchInput { cancel() }
+    compose.runOnIdle { assertEquals("q", text) }
+    compose.onNodeWithContentDescription("Alternative 1").assertDoesNotExist()
+  }
+
+  @Test
+  fun holdingHighlightsDefaultAndReleaseCommitsAndDismisses() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    holdKey("q")
+    compose.onNodeWithContentDescription("Alternative 1").assertIsSelected()
+    compose.runOnIdle { assertEquals("", text) }
+    compose.onNodeWithText("q").performTouchInput { up() }
+    compose.runOnIdle { assertEquals("1", text) }
+    compose.onNodeWithContentDescription("Alternative 1").assertDoesNotExist()
+  }
+
+  @Test
+  fun longPressOffersHintedNumberWithoutTypingTheLetter() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    compose.onNodeWithText("q").performTouchInput { longClick() }
+    compose.runOnIdle { assertEquals("1", text) }
+    compose.onNodeWithContentDescription("Alternative 1").assertDoesNotExist()
+  }
+
+  @Test
+  fun bracketAlternativesAndOrdinaryTapsStaySeparate() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    compose.onNodeWithText("k").performClick()
+    holdKey("k")
+    val step = with(compose.density) { 36.dp.toPx() }
+    compose.onNodeWithText("k").performTouchInput {
+      moveBy(Offset(-step, 0f))
+      up()
+    }
+    compose.runOnIdle { assertEquals("k[", text) }
+  }
+
+  @Test
+  fun spacePreviewStillInsertsASpaceAndReturnsToNormalWhenCleared() {
+    var text = ""
+    val preview = androidx.compose.runtime.mutableStateOf<String?>("YouTube")
+    compose.setContent {
+      MaterialTheme {
+        HomeSearchKeyboard(
+          { text += it },
+          {},
+          {},
+          Modifier.height(243.dp),
+          spaceShortcutLabel = preview.value,
+          spaceShortcutIcon = androidx.compose.ui.graphics.ImageBitmap(16, 16),
+        )
+      }
+    }
+    compose.onNodeWithText("Search YouTube").assertExists()
+    compose.onNodeWithContentDescription("Space: activate YouTube search").performClick()
+    compose.runOnIdle {
+      assertEquals(" ", text)
+      preview.value = null
+    }
+    compose.onNodeWithContentDescription("Space").assertExists()
+    compose.onNodeWithText("Search YouTube").assertDoesNotExist()
+  }
+
+  @Test
+  fun shortcutHintsKeepTypingLettersAndDisappearOnSymbols() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme {
+        HomeSearchKeyboard(
+          { text += it },
+          {},
+          {},
+          Modifier.height(243.dp),
+          shortcutHints =
+            mapOf(
+              'y' to
+                KeyboardShortcutHint("YouTube", androidx.compose.ui.graphics.ImageBitmap(16, 16))
+            ),
+        )
+      }
+    }
+    compose.onNodeWithText("YouTube").assertDoesNotExist()
+    compose.onNodeWithContentDescription("y, YouTube shortcut").performClick()
+    compose.runOnIdle { assertEquals("y", text) }
+    compose.onNodeWithContentDescription("Numbers and symbols").performClick()
+    compose.onNodeWithContentDescription("y, YouTube shortcut").assertDoesNotExist()
+  }
+
+  @Test
+  fun goUsesSelectedResultIconAndAccessibleName() {
+    var opened = false
+    val icon = androidx.compose.ui.graphics.ImageBitmap(16, 16)
+    compose.setContent {
+      MaterialTheme {
+        HomeSearchKeyboard(
+          {},
+          {},
+          { opened = true },
+          Modifier.height(243.dp),
+          goIcon = icon,
+          goDescription = "Go: YouTube",
+        )
+      }
+    }
+    compose.onNodeWithText("Go").assertDoesNotExist()
+    compose.onNodeWithContentDescription("Go: YouTube").performClick()
+    compose.runOnIdle { assertTrue(opened) }
+  }
+
+  @Test
+  fun shiftIsOneShotAndSymbolsCanReturnToLetters() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    compose.onNodeWithContentDescription("Shift").performClick()
+    compose.onNodeWithText("A").performClick()
+    compose.onNodeWithText("b").performClick()
+    compose.onNodeWithContentDescription("Numbers and symbols").performClick()
+    compose.onNodeWithText("1").performClick()
+    compose.onNodeWithContentDescription("Letters").performClick()
+    compose.onNodeWithText("c").performClick()
+    compose.runOnIdle { assertEquals("Ab1c", text) }
+  }
+
+  @Test
+  fun accentLongPressInsertsOnlyChosenAccent() {
+    var text = ""
+    compose.setContent {
+      MaterialTheme { HomeSearchKeyboard({ text += it }, {}, {}, Modifier.height(243.dp)) }
+    }
+    holdKey("e")
+    val step = with(compose.density) { 72.dp.toPx() }
+    compose.onNodeWithText("e").performTouchInput {
+      moveBy(Offset(step, 0f))
+      up()
+    }
+    compose.runOnIdle { assertEquals("é", text) }
+  }
+
+  @Test
+  fun goAndBackspaceUseTheirOwnActions() {
+    var deletes = 0
+    var go = false
+    compose.setContent {
+      MaterialTheme {
+        HomeSearchKeyboard({}, { deletes++ }, { go = true }, Modifier.height(243.dp))
+      }
+    }
+    compose.onNodeWithContentDescription("Backspace").performClick()
+    compose.onNodeWithContentDescription("Go: open search result").performClick()
+    compose.runOnIdle {
+      assertEquals(1, deletes)
+      assertTrue(go)
+    }
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/HomeKeyboardEditing.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/HomeKeyboardEditing.kt
@@ -1,0 +1,34 @@
+package com.searchlauncher.app.ui
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import java.text.BreakIterator
+
+/** Replace the selection, including a reversed selection, and discard any old IME composition. */
+internal fun TextFieldValue.insertKeyboardText(inserted: String): TextFieldValue {
+  val start = selection.min
+  val end = selection.max
+  return TextFieldValue(text.replaceRange(start, end, inserted), TextRange(start + inserted.length))
+}
+
+/** Delete a selected range or the previous character boundary, never half of a surrogate pair. */
+internal fun TextFieldValue.deleteKeyboardText(): TextFieldValue {
+  if (!selection.collapsed) return insertKeyboardText("")
+  val end = selection.start
+  if (end == 0) return this
+  val boundaries = BreakIterator.getCharacterInstance().also { it.setText(text) }
+  val start = boundaries.preceding(end).coerceAtLeast(0)
+  return TextFieldValue(text.removeRange(start, end), TextRange(start))
+}
+
+/** Preview only when inserting a space at the caret would complete the entire shortcut alias. */
+internal fun pendingKeyboardShortcut(
+  value: TextFieldValue,
+  shortcuts: List<com.searchlauncher.app.data.SearchShortcut>,
+): com.searchlauncher.app.data.SearchShortcut? {
+  if (
+    !value.selection.collapsed || value.selection.end != value.text.length || value.text.isEmpty()
+  )
+    return null
+  return shortcuts.firstOrNull { it.alias.equals(value.text, ignoreCase = true) }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/HomeKeyboardPreference.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/HomeKeyboardPreference.kt
@@ -1,0 +1,36 @@
+package com.searchlauncher.app.ui
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import com.searchlauncher.app.data.Prefs
+import kotlinx.coroutines.flow.map
+
+/** Synchronous boot cache prevents a different keyboard flashing before DataStore loads. */
+object HomeKeyboardPreference {
+  private const val CACHE_KEY = "built_in_keyboard"
+
+  fun cached(context: Context): Boolean =
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .getBoolean(CACHE_KEY, true)
+
+  fun flow(context: Context) =
+    context.dataStore.data.map {
+      val enabled = it[PreferencesKeys.BUILT_IN_KEYBOARD] ?: true
+      cache(context, enabled)
+      enabled
+    }
+
+  suspend fun set(context: Context, enabled: Boolean) {
+    context.dataStore.edit { it[PreferencesKeys.BUILT_IN_KEYBOARD] = enabled }
+    cache(context, enabled)
+  }
+
+  private fun cache(context: Context, enabled: Boolean) {
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .putBoolean(CACHE_KEY, enabled)
+      .apply()
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/Ime.kt
@@ -47,6 +47,16 @@ object Ime {
     window.setSoftInputMode(SOFT_INPUT_MODE)
   }
 
+  /** Keep Android from automatically showing an IME behind the embedded home keyboard. */
+  fun applyHomeWindowMode(window: Window, builtInKeyboard: Boolean) {
+    if (builtInKeyboard) {
+      window.setSoftInputMode(
+        WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN or
+          WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+      )
+    } else applyWindowMode(window)
+  }
+
   /**
    * IME inset to pad the chrome with. Live values larger than [MAX_HEIGHT_FRACTION] of the screen
    * are the IME window reporting itself as full-screen while the keys are not; using them shoved

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -472,7 +472,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     appWidgetHost = android.appwidget.AppWidgetHost(applicationContext, APPWIDGET_HOST_ID)
     queryState = savedInstanceState?.getString(KEY_ACTIVE_QUERY) ?: restoreRecentQuery()
     enableEdgeToEdge()
-    Ime.applyWindowMode(window)
+    Ime.applyHomeWindowMode(window, HomeKeyboardPreference.cached(this))
 
     setContent {
       val themeColor =
@@ -585,7 +585,12 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
-    if (hasFocus && currentScreenState == Screen.Search && !inPictureInPicture) {
+    if (
+      hasFocus &&
+        currentScreenState == Screen.Search &&
+        !inPictureInPicture &&
+        !HomeKeyboardPreference.cached(this)
+    ) {
       // Show here, but do not bump [focusTrigger]: that restarts the Compose IME loop and
       // cancels the request that onResume already started. Do not hide in onPause either —
       // that tears the IME process down, and the next home arrival waits on a cold start.

--- a/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/PreferencesKeys.kt
@@ -33,6 +33,9 @@ object PreferencesKeys {
   val THEMED_ICONS = booleanPreferencesKey("themed_icons")
   val SEARCH_SHORTCUTS_ENABLED = booleanPreferencesKey("search_shortcuts_enabled")
 
+  /** Built-in home search keyboard; other editors continue using the system keyboard. */
+  val BUILT_IN_KEYBOARD = booleanPreferencesKey("built_in_keyboard")
+
   /**
    * Whether the keyboard may autocorrect what is typed into the search bar. Off by default: a query
    * is usually a name, a command or a URL fragment, and having it silently rewritten into a

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -36,7 +35,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Mic
@@ -120,6 +118,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 fun SearchScreen(
   query: String,
@@ -227,11 +226,11 @@ fun SearchScreen(
   val autocorrectEnabled by
     remember { context.dataStore.data.map { it[PreferencesKeys.SEARCH_AUTOCORRECT] ?: false } }
       .collectAsState(initial = false)
-  val defaultSearchEngineId by
-    remember {
-        context.dataStore.data.map { it[PreferencesKeys.DEFAULT_SEARCH_ENGINE] ?: "google" }
-      }
-      .collectAsState(initial = "google")
+  val builtInKeyboardEnabled by
+    remember { HomeKeyboardPreference.flow(context) }
+      .collectAsState(initial = HomeKeyboardPreference.cached(context))
+  val useBuiltInKeyboard = builtInKeyboardEnabled && !riseWithKeyboard && browserTabId == null
+  var keyboardDismissed by remember { mutableStateOf(false) }
 
   // Sync back to the boot cache so the next cold start renders at this size immediately.
   LaunchedEffect(minIconSizeSetting) { MinIconSize.updateCache(context, minIconSizeSetting) }
@@ -735,6 +734,148 @@ fun SearchScreen(
     }
   }
 
+  val activeShortcut =
+    remember(query) {
+      var shortcut =
+        app.searchShortcutRepository.items.value.find {
+          query.startsWith("${it.alias} ", ignoreCase = true)
+        }
+      if (shortcut == null) {
+        shortcut =
+          com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
+            query.startsWith("${it.alias} ", ignoreCase = true)
+          }
+      }
+      shortcut
+    }
+
+  val displayQuery =
+    if (activeShortcut != null) {
+      query.substring("${activeShortcut.alias} ".length)
+    } else {
+      query
+    }
+
+  var textFieldValue by remember {
+    mutableStateOf(
+      androidx.compose.ui.text.input.TextFieldValue(
+        text = displayQuery,
+        selection = androidx.compose.ui.text.TextRange(displayQuery.length),
+      )
+    )
+  }
+
+  // Update TextFieldValue when displayQuery changes externally (e.g. from "Add Widget")
+  LaunchedEffect(displayQuery) {
+    if (textFieldValue.text != displayQuery) {
+      textFieldValue =
+        textFieldValue.copy(
+          text = displayQuery,
+          selection = androidx.compose.ui.text.TextRange(displayQuery.length),
+        )
+    }
+  }
+
+  fun updateSearchField(newValue: androidx.compose.ui.text.input.TextFieldValue) {
+    textFieldValue = newValue
+    onQueryChange(
+      if (activeShortcut != null) "${activeShortcut.alias} ${newValue.text}" else newValue.text
+    )
+  }
+
+  val selectedSearchResult =
+    searchResults.getOrNull(keyboardSelectedIndex) ?: searchResults.firstOrNull()
+  var selectedResultIcon by
+    remember(
+      selectedSearchResult?.id,
+      selectedSearchResult?.namespace,
+      selectedSearchResult?.icon,
+    ) {
+      mutableStateOf(selectedSearchResult?.icon)
+    }
+  LaunchedEffect(selectedSearchResult, useBuiltInKeyboard) {
+    if (useBuiltInKeyboard && selectedResultIcon == null) {
+      selectedSearchResult?.let { selectedResultIcon = searchRepository.loadIcon(it) }
+    }
+  }
+  val keyboardShortcutHints =
+    remember(searchShortcuts) {
+      searchShortcuts
+        .filter { it.alias.length == 1 && it.alias[0].isLetter() }
+        .associate {
+          it.alias[0].lowercaseChar() to
+            com.searchlauncher.app.ui.components.KeyboardShortcutHint(
+              label = it.shortLabel ?: it.description,
+              icon =
+                iconGenerator
+                  .getColoredSearchIcon(it.color ?: 0xFF808080, it.alias)
+                  ?.toImageBitmap(),
+            )
+        }
+    }
+
+  val pendingSpaceShortcut =
+    if (activeShortcut == null) {
+      pendingKeyboardShortcut(textFieldValue, searchShortcuts)
+    } else null
+  val pendingSpaceIcon =
+    remember(pendingSpaceShortcut) {
+      pendingSpaceShortcut?.let {
+        iconGenerator.getColoredSearchIcon(it.color, it.alias)?.toImageBitmap()
+      }
+    }
+
+  fun submitSearch() {
+    val topResult = selectedSearchResult
+    if (topResult != null) {
+      if (topResult is SearchResult.SearchIntent) {
+        if (isFallbackMode && query.isNotEmpty()) {
+          // In fallback mode (e.g. random
+          // text), 'Go' should perform the
+          // search
+          // using the top shortcut, instead
+          // of just expanding the filter.
+          val shortcut =
+            app.searchShortcutRepository.items.value.find { it.alias == topResult.trigger }
+
+          if (shortcut != null) {
+            launchShortcutSearch(
+              context = context,
+              searchRepository = searchRepository,
+              shortcut = shortcut,
+              result = topResult,
+              query = query,
+              privateWebResults = privateWebResults,
+              wasFirstResult = keyboardSelectedIndex == 0,
+              openInBrowser = { openInBrowser(it) },
+              onDismiss = onDismiss,
+            )
+          } else {
+            // Should not happen if data
+            // integrity is good, but
+            // fallback:
+            onQueryChange(topResult.trigger + " ")
+          }
+        } else {
+          // Normal mode: pressing enter on a
+          // shortcut expands it (sub-search)
+          onQueryChange(topResult.trigger + " ")
+        }
+      } else {
+        launchResultPreferringPrivateBrowser(
+          context = context,
+          result = topResult,
+          query = query,
+          searchShortcuts = searchShortcuts,
+          privateWebResults = privateWebResults,
+          resultLauncher = resultLauncher,
+          wasFirstResult = keyboardSelectedIndex == 0,
+        )
+        onDismiss()
+      }
+    }
+  }
+
   // Focus the field as soon as it exists, even before this window has focus. The IME can only
   // actually appear once the window is focused, but an editor that is already focused when that
   // happens is what the system needs to start the keyboard on the same frame — waiting for
@@ -746,12 +887,22 @@ fun SearchScreen(
   val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
   val shouldShowKeyboard =
     rememberUpdatedState(isActive && !openingTab && !browserShowing && !inPip)
-  LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip) {
+  LaunchedEffect(isActive, focusTrigger, browserShowing, openingTab, inPip, useBuiltInKeyboard) {
+    keyboardDismissed = false
+    if (!riseWithKeyboard && browserTabId == null) {
+      (context as? android.app.Activity)?.window?.let {
+        Ime.applyHomeWindowMode(it, useBuiltInKeyboard)
+      }
+    }
     if (!shouldShowKeyboard.value) {
       Ime.hide(view)
       return@LaunchedEffect
     }
     runCatching { focusRequester.requestFocus() }
+    if (useBuiltInKeyboard) {
+      Ime.hide(view)
+      return@LaunchedEffect
+    }
     snapshotFlow { windowInfo.isWindowFocused }
       .collect { focused ->
         if (!focused || !shouldShowKeyboard.value) return@collect
@@ -776,11 +927,12 @@ fun SearchScreen(
   // Tapping the field when it is already focused produces no focus change, so nothing would
   // re-open a dismissed keyboard; show it explicitly on every press.
   val searchFieldInteractionSource = remember { MutableInteractionSource() }
-  LaunchedEffect(searchFieldInteractionSource) {
+  LaunchedEffect(searchFieldInteractionSource, useBuiltInKeyboard) {
     searchFieldInteractionSource.interactions.collect { interaction ->
       if (interaction is androidx.compose.foundation.interaction.PressInteraction.Release) {
         focusRequester.requestFocus()
-        Ime.show(view)
+        keyboardDismissed = false
+        if (!useBuiltInKeyboard) Ime.show(view)
       }
     }
   }
@@ -971,13 +1123,18 @@ fun SearchScreen(
   val reservedKeyboardHeightPx = Ime.reservedHeightPx(storedKeyboardHeight, screenHeightPx)
   val imeForLayoutPx = Ime.insetForLayoutPx(imeHeightPx, storedKeyboardHeight, screenHeightPx)
 
-  // Chrome follows the live IME inset, including on home. A stored-height park put the bar in
+  // With the system keyboard, chrome follows the live IME inset. A stored-height park put the bar
+  // in
   // mid-air above an empty well; a full-screen IME reading shoved it off the top. [imeForLayoutPx]
   // is the live inset with those two cases stripped.
   val navigationBarBottomPx = WindowInsets.navigationBars.getBottom(density)
+  val builtInKeyboardVisible = useBuiltInKeyboard && shouldShowKeyboard.value && !keyboardDismissed
+  val builtInKeyboardHeight = minOf(243.dp, (LocalConfiguration.current.screenHeightDp * 0.45f).dp)
   val bottomPadding =
     with(density) {
       when {
+        useBuiltInKeyboard ->
+          navigationBarBottomPx.toDp() + if (builtInKeyboardVisible) builtInKeyboardHeight else 0.dp
         // Tracks the IME inset frame by frame as the keyboard animates in, so the bar travels up
         // with the keys. At rest it lands exactly on the bar it replaces, so the overlay opens
         // without the bar hopping.
@@ -1004,6 +1161,7 @@ fun SearchScreen(
    */
   val wallpaperBottomPadding =
     when {
+      useBuiltInKeyboard -> builtInKeyboardHeight + with(density) { navigationBarBottomPx.toDp() }
       riseWithKeyboard || isMultiWindow -> bottomPadding
       else -> with(density) { reservedKeyboardHeightPx.toDp() }
     }
@@ -1088,6 +1246,8 @@ fun SearchScreen(
   // The overlay is its own activity: back has to finish it, not merely hide the keyboard. The
   // activity also intercepts BACK before the IME (see SearchActivity); this covers the case where
   // the keys are already gone.
+  BackHandler(enabled = builtInKeyboardVisible && !tabsOverviewOpen) { keyboardDismissed = true }
+
   BackHandler(enabled = tabsOverviewOpen || riseWithKeyboard) {
     if (tabsOverviewOpen) tabsOverviewOpen = false else onDismiss()
   }
@@ -1815,21 +1975,6 @@ fun SearchScreen(
             // color — a shadow keeps it readable as its own layer.
             shadowElevation = if (chromeBarColor != null) 8.dp else 0.dp,
           ) {
-            val activeShortcut =
-              remember(query) {
-                var shortcut =
-                  app.searchShortcutRepository.items.value.find {
-                    query.startsWith("${it.alias} ", ignoreCase = true)
-                  }
-                if (shortcut == null) {
-                  shortcut =
-                    com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts.find {
-                      query.startsWith("${it.alias} ", ignoreCase = true)
-                    }
-                }
-                shortcut
-              }
-
             if (activeShortcut != null) {
               Surface(
                 color = androidx.compose.ui.graphics.Color(activeShortcut.color ?: 0xFF808080),
@@ -1861,261 +2006,83 @@ fun SearchScreen(
               }
             }
 
-            val displayQuery =
-              if (activeShortcut != null) {
-                query.substring("${activeShortcut.alias} ".length)
-              } else {
-                query
+            androidx.compose.ui.platform.InterceptPlatformTextInput(
+              interceptor = { request, next ->
+                if (useBuiltInKeyboard) kotlinx.coroutines.awaitCancellation()
+                else next.startInputMethod(request)
               }
-
-            var textFieldValue by remember {
-              mutableStateOf(
-                androidx.compose.ui.text.input.TextFieldValue(
-                  text = displayQuery,
-                  selection = androidx.compose.ui.text.TextRange(displayQuery.length),
-                )
-              )
-            }
-
-            // Update TextFieldValue when displayQuery changes externally (e.g. from "Add Widget")
-            LaunchedEffect(displayQuery) {
-              if (textFieldValue.text != displayQuery) {
-                textFieldValue =
-                  textFieldValue.copy(
-                    text = displayQuery,
-                    selection = androidx.compose.ui.text.TextRange(displayQuery.length),
-                  )
-              }
-            }
-
-            BasicTextField(
-              value = textFieldValue,
-              onValueChange = { newValue ->
-                textFieldValue = newValue
-                val newText = newValue.text
-                if (activeShortcut != null) {
-                  onQueryChange("${activeShortcut.alias} $newText")
-                } else {
-                  onQueryChange(newText)
-                }
-              },
-              modifier =
-                Modifier.weight(1f)
-                  .focusRequester(focusRequester)
-                  .onFocusChanged { state ->
-                    if (state.isFocused && shouldShowKeyboard.value) {
-                      Ime.show(view)
-                    }
-                  }
-                  .onKeyEvent { event ->
-                    if (
-                      event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
-                        displayQuery.isEmpty() &&
-                        activeShortcut != null
-                    ) {
-                      onQueryChange("")
-                      true
-                    } else {
-                      false
-                    }
-                  },
-              textStyle =
-                LocalTextStyle.current.copy(fontSize = 16.sp, color = LocalContentColor.current),
-              // Autocorrect off keeps the query literal: package names, commands and URL fragments
-              // are not dictionary words, and a silent rewrite is harder to notice than a typo.
-              keyboardOptions =
-                KeyboardOptions(imeAction = ImeAction.Go, autoCorrectEnabled = autocorrectEnabled),
-              keyboardActions =
-                KeyboardActions(
-                  onGo = {
-                    val topResult =
-                      searchResults.getOrNull(keyboardSelectedIndex) ?: searchResults.firstOrNull()
-                    if (topResult != null) {
-                      if (topResult is SearchResult.SearchIntent) {
-                        if (isFallbackMode && query.isNotEmpty()) {
-                          // In fallback mode (e.g. random
-                          // text), 'Go' should perform the
-                          // search
-                          // using the top shortcut, instead
-                          // of just expanding the filter.
-                          val shortcut =
-                            app.searchShortcutRepository.items.value.find {
-                              it.alias == topResult.trigger
-                            }
-
-                          if (shortcut != null) {
-                            launchShortcutSearch(
-                              context = context,
-                              searchRepository = searchRepository,
-                              shortcut = shortcut,
-                              result = topResult,
-                              query = query,
-                              privateWebResults = privateWebResults,
-                              wasFirstResult = keyboardSelectedIndex == 0,
-                              openInBrowser = { openInBrowser(it) },
-                              onDismiss = onDismiss,
-                            )
-                          } else {
-                            // Should not happen if data
-                            // integrity is good, but
-                            // fallback:
-                            onQueryChange(topResult.trigger + " ")
-                          }
-                        } else {
-                          // Normal mode: pressing enter on a
-                          // shortcut expands it (sub-search)
-                          onQueryChange(topResult.trigger + " ")
-                        }
-                      } else {
-                        launchResultPreferringPrivateBrowser(
-                          context = context,
-                          result = topResult,
-                          query = query,
-                          searchShortcuts = searchShortcuts,
-                          privateWebResults = privateWebResults,
-                          resultLauncher = resultLauncher,
-                          wasFirstResult = keyboardSelectedIndex == 0,
-                        )
-                        onDismiss()
+            ) {
+              BasicTextField(
+                value = textFieldValue,
+                onValueChange = ::updateSearchField,
+                singleLine = true,
+                modifier =
+                  Modifier.weight(1f)
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { state ->
+                      if (state.isFocused && shouldShowKeyboard.value && !useBuiltInKeyboard) {
+                        Ime.show(view)
                       }
                     }
-                  }
-                ),
-              cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-              interactionSource = searchFieldInteractionSource,
-              decorationBox = { innerTextField ->
-                Box(contentAlignment = Alignment.CenterStart) {
-                  if (displayQuery.isEmpty() && activeShortcut == null) {
-                    if (isListening) {
-                      Text(
-                        text = "Listening...",
-                        color = MaterialTheme.colorScheme.primary,
-                        fontSize = 16.sp,
-                        maxLines = 1,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                      )
-                    } else {
-                      AnimatedContent(
-                        targetState = currentHint,
-                        transitionSpec = { fadeIn() togetherWith fadeOut() },
-                        label = "HintAnimation",
-                      ) { targetHint ->
+                    .onKeyEvent { event ->
+                      if (
+                        event.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_DEL &&
+                          displayQuery.isEmpty() &&
+                          activeShortcut != null
+                      ) {
+                        onQueryChange("")
+                        true
+                      } else {
+                        false
+                      }
+                    },
+                textStyle =
+                  LocalTextStyle.current.copy(fontSize = 16.sp, color = LocalContentColor.current),
+                // Autocorrect off keeps the query literal: package names, commands and URL
+                // fragments
+                // are not dictionary words, and a silent rewrite is harder to notice than a typo.
+                keyboardOptions =
+                  KeyboardOptions(
+                    imeAction = ImeAction.Go,
+                    autoCorrectEnabled = autocorrectEnabled,
+                  ),
+                keyboardActions = KeyboardActions(onGo = { submitSearch() }),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                interactionSource = searchFieldInteractionSource,
+                decorationBox = { innerTextField ->
+                  Box(contentAlignment = Alignment.CenterStart) {
+                    if (displayQuery.isEmpty() && activeShortcut == null) {
+                      if (isListening) {
                         Text(
-                          text = targetHint,
-                          color = LocalContentColor.current.copy(alpha = 0.72f),
+                          text = "Listening...",
+                          color = MaterialTheme.colorScheme.primary,
                           fontSize = 16.sp,
                           maxLines = 1,
                           overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                         )
+                      } else {
+                        AnimatedContent(
+                          targetState = currentHint,
+                          transitionSpec = { fadeIn() togetherWith fadeOut() },
+                          label = "HintAnimation",
+                        ) { targetHint ->
+                          Text(
+                            text = targetHint,
+                            color = LocalContentColor.current.copy(alpha = 0.72f),
+                            fontSize = 16.sp,
+                            maxLines = 1,
+                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                          )
+                        }
                       }
                     }
+                    innerTextField()
                   }
-                  innerTextField()
-                }
-              },
-            )
+                },
+              )
+            }
 
             if (query.isNotEmpty()) {
-              // Resolved once and shared by the badge, the tap and the menu, so what the button
-              // shows, what it does and what the menu ticks cannot drift apart.
-              val engines =
-                remember(searchShortcuts) {
-                  (com.searchlauncher.app.data.DefaultShortcuts.searchShortcuts + searchShortcuts)
-                    .filter { it.urlTemplate.startsWith("http") }
-                    .distinctBy { it.id }
-                }
-              val engine =
-                remember(engines, defaultSearchEngineId) {
-                  engines.firstOrNull { it.id == defaultSearchEngineId }
-                    ?: engines.firstOrNull { it.id == "google" }
-                    ?: engines.first()
-                }
-              var engineMenuOpen by remember { mutableStateOf(false) }
-
-              Box {
-                // Drawn here rather than scaled down from the generator's 40dp bitmap, which at
-                // this
-                // size rounded off into a circle. Same recipe as the badges in the result list —
-                // the
-                // engine's colour, its alias on it — at a fifth of the side, which is the corner
-                // they
-                // are drawn with, so the two read as the same shape.
-                Surface(
-                  color = Color(engine.color ?: 0xFF808080),
-                  shape = RoundedCornerShape(percent = 20),
-                  modifier =
-                    Modifier.size(24.dp)
-                      .combinedClickable(
-                        onClick = {
-                          openBrowser(context, engine.urlForQuery(query), privateWebResults) {
-                            openInBrowser(it)
-                          }
-                          onDismiss()
-                        },
-                        onLongClick = { engineMenuOpen = true },
-                      ),
-                ) {
-                  Box(contentAlignment = Alignment.Center) {
-                    Text(
-                      text = engine.alias.uppercase(),
-                      color = Color.White,
-                      fontSize = 11.sp,
-                      fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                      maxLines = 1,
-                    )
-                  }
-                }
-
-                // The same list the settings page offers, written to the same preference, so
-                // changing
-                // it here is changing it there.
-                DropdownMenu(
-                  expanded = engineMenuOpen,
-                  onDismissRequest = { engineMenuOpen = false },
-                ) {
-                  Text(
-                    text = "Set default search engine",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                  )
-                  engines.forEach { candidate ->
-                    DropdownMenuItem(
-                      text = { Text(candidate.shortLabel ?: candidate.description) },
-                      onClick = {
-                        engineMenuOpen = false
-                        scope.launch {
-                          context.dataStore.edit { preferences ->
-                            preferences[PreferencesKeys.DEFAULT_SEARCH_ENGINE] = candidate.id
-                          }
-                        }
-                      },
-                      leadingIcon = {
-                        Surface(
-                          color = Color(candidate.color ?: 0xFF808080),
-                          shape = RoundedCornerShape(percent = 20),
-                          modifier = Modifier.size(24.dp),
-                        ) {
-                          Box(contentAlignment = Alignment.Center) {
-                            Text(
-                              text = candidate.alias.uppercase(),
-                              color = Color.White,
-                              fontSize = 11.sp,
-                              fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                              maxLines = 1,
-                            )
-                          }
-                        }
-                      },
-                      trailingIcon = {
-                        if (candidate.id == engine.id) {
-                          Icon(Icons.Default.Check, contentDescription = "Current default")
-                        }
-                      },
-                    )
-                  }
-                }
-              }
               IconButton(
                 onClick = { onQueryChange("") },
                 modifier = Modifier.size(32.dp).padding(4.dp),
@@ -2185,6 +2152,31 @@ fun SearchScreen(
             }
           }
         }
+      }
+      if (builtInKeyboardVisible) {
+        com.searchlauncher.app.ui.components.HomeSearchKeyboard(
+          modifier =
+            Modifier.align(Alignment.BottomCenter)
+              .padding(bottom = with(density) { navigationBarBottomPx.toDp() })
+              .fillMaxWidth()
+              .height(builtInKeyboardHeight),
+          onText = { updateSearchField(textFieldValue.insertKeyboardText(it)) },
+          onBackspace = {
+            if (displayQuery.isEmpty() && activeShortcut != null) onQueryChange("")
+            else updateSearchField(textFieldValue.deleteKeyboardText())
+          },
+          onGo = ::submitSearch,
+          shortcutHints = if (query.isEmpty()) keyboardShortcutHints else emptyMap(),
+          spaceShortcutLabel = pendingSpaceShortcut?.let { it.shortLabel ?: it.description },
+          spaceShortcutIcon = pendingSpaceIcon,
+          goIcon =
+            rememberThemedIconBitmap(
+              selectedResultIcon,
+              (selectedSearchResult as? SearchResult.App)?.packageName,
+            ),
+          goDescription =
+            selectedSearchResult?.let { "Go: ${it.title}" } ?: "Go: open search result",
+        )
       }
     }
   }

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -674,6 +674,9 @@ private fun DefaultSearchEngineCard() {
       .collectAsState(initial = "google")
   val selectedEngine = engines.firstOrNull { it.id == selectedEngineId } ?: engines.firstOrNull()
   var menuExpanded by remember { mutableStateOf(false) }
+  val builtInKeyboardEnabled by
+    remember { HomeKeyboardPreference.flow(context) }
+      .collectAsState(initial = HomeKeyboardPreference.cached(context))
   val autocorrectEnabled by
     remember { context.dataStore.data.map { it[PreferencesKeys.SEARCH_AUTOCORRECT] ?: false } }
       .collectAsState(initial = false)
@@ -681,6 +684,24 @@ private fun DefaultSearchEngineCard() {
   Card(modifier = Modifier.fillMaxWidth()) {
     Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(text = "Search", style = MaterialTheme.typography.titleMedium)
+
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+          Text("Use built-in keyboard", style = MaterialTheme.typography.bodyMedium)
+          Text(
+            "Home search only. Turn off to use your own keyboard. The built-in keyboard supports " +
+              "QWERTY and accented letters; use your own for swipe typing or other languages.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        Switch(
+          checked = builtInKeyboardEnabled,
+          onCheckedChange = { enabled ->
+            scope.launch { HomeKeyboardPreference.set(context, enabled) }
+          },
+        )
+      }
 
       Row(
         modifier = Modifier.fillMaxWidth(),
@@ -723,7 +744,7 @@ private fun DefaultSearchEngineCard() {
         verticalAlignment = Alignment.CenterVertically,
       ) {
         Column(modifier = Modifier.weight(1f)) {
-          Text(text = "Keyboard autocorrect", style = MaterialTheme.typography.bodyMedium)
+          Text(text = "System keyboard autocorrect", style = MaterialTheme.typography.bodyMedium)
           Text(
             text =
               "Let the keyboard correct what you type in the search bar. Off keeps queries " +

--- a/app/src/main/java/com/searchlauncher/app/ui/components/HomeSearchKeyboard.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/HomeSearchKeyboard.kt
@@ -1,0 +1,411 @@
+package com.searchlauncher.app.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
+
+private val accents =
+  mapOf(
+    'a' to "àáâäæãå",
+    'c' to "çćč",
+    'e' to "èéêë",
+    'i' to "ìíîï",
+    'n' to "ñń",
+    'o' to "òóôöœõø",
+    's' to "ßśš",
+    'u' to "ùúûü",
+    'y' to "ýÿ",
+    'z' to "žźż",
+  )
+
+// Fixed QWERTY hints: numbers on the top row, punctuation beneath it.
+private val keySymbols =
+  ("qwertyuiop".zip("1234567890") + "asdfghjkl".zip("@#$%&-+()") + "zxcvbnm".zip("*\"':;!?"))
+    .toMap()
+
+data class KeyboardShortcutHint(val label: String, val icon: ImageBitmap?)
+
+/** Home-only keyboard. Its parent owns the height so the search bar and keys land together. */
+@Composable
+fun HomeSearchKeyboard(
+  onText: (String) -> Unit,
+  onBackspace: () -> Unit,
+  onGo: () -> Unit,
+  modifier: Modifier = Modifier,
+  shortcutHints: Map<Char, KeyboardShortcutHint> = emptyMap(),
+  goIcon: ImageBitmap? = null,
+  goDescription: String = "Go: open search result",
+  spaceShortcutLabel: String? = null,
+  spaceShortcutIcon: ImageBitmap? = null,
+) {
+  var shift by remember { mutableStateOf(false) }
+  var capsLock by remember { mutableStateOf(false) }
+  var symbols by remember { mutableStateOf(false) }
+  var extraSymbols by remember { mutableStateOf(false) }
+  fun type(text: String) {
+    onText(if (shift || capsLock) text.uppercase() else text)
+    if (!capsLock) shift = false
+  }
+  val platformConfiguration = LocalViewConfiguration.current
+  val keyboardConfiguration =
+    remember(platformConfiguration) {
+      object : ViewConfiguration by platformConfiguration {
+        override val longPressTimeoutMillis: Long = 250L
+      }
+    }
+  CompositionLocalProvider(LocalViewConfiguration provides keyboardConfiguration) {
+    Surface(
+      modifier,
+      color = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+      Column(
+        Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+      ) {
+        val rows =
+          if (!symbols) listOf("qwertyuiop", "asdfghjkl", "zxcvbnm")
+          else if (!extraSymbols) listOf("1234567890", "@#€%&-+()", "*\"':;!?/")
+          else listOf("~`|•√π÷×§∆", "£¢$^°={}\\", "_[]<>:,.")
+        rows.forEachIndexed { index, letters ->
+          Row(
+            Modifier.fillMaxWidth().weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+          ) {
+            if (index == 1) Spacer(Modifier.weight(0.5f))
+            if (index == 2) {
+              KeyboardKey(
+                label = if (symbols) "=\\<" else if (capsLock) "⇪" else "⇧",
+                description =
+                  if (symbols) "More symbols" else if (capsLock) "Caps lock on" else "Shift",
+                modifier = Modifier.weight(1.4f).fillMaxHeight(),
+                selected = shift || capsLock,
+                onClick = {
+                  if (symbols) extraSymbols = !extraSymbols
+                  else {
+                    shift = !shift
+                    capsLock = false
+                  }
+                },
+                onLongClick =
+                  if (symbols) null
+                  else
+                    ({
+                      capsLock = !capsLock
+                      shift = capsLock
+                    }),
+              )
+            }
+            letters.forEach { letter ->
+              val symbolHint = if (symbols) null else keySymbols[letter]
+              val alternatives =
+                if (symbols) emptyList()
+                else
+                  buildList {
+                    symbolHint?.let { add(it) }
+                    // Related bracket styles stay together without needing another keyboard page.
+                    if (letter == 'k') addAll("[{".toList())
+                    if (letter == 'l') addAll("]}".toList())
+                    addAll(accents[letter].orEmpty().toList())
+                  }
+              Box(Modifier.weight(1f).fillMaxHeight()) {
+                KeyboardKey(
+                  label = if (shift || capsLock) letter.uppercase() else letter.toString(),
+                  modifier = Modifier.fillMaxSize(),
+                  hint = if (symbols) null else shortcutHints[letter],
+                  symbolHint = symbolHint?.toString(),
+                  description =
+                    shortcutHints[letter]
+                      ?.takeIf { !symbols }
+                      ?.let { "$letter, ${it.label} shortcut" }
+                      ?: if (shift || capsLock) letter.uppercase() else letter.toString(),
+                  onClick = { type(letter.toString()) },
+                  alternatives =
+                    alternatives.map { if (shift || capsLock) it.uppercase() else it.toString() },
+                  onAlternative = { type(it) },
+                )
+              }
+            }
+            if (index == 1) Spacer(Modifier.weight(0.5f))
+            if (index == 2)
+              KeyboardKey(
+                "⌫",
+                onBackspace,
+                Modifier.weight(1.4f).fillMaxHeight(),
+                description = "Backspace",
+                repeat = true,
+              )
+          }
+        }
+        Row(
+          Modifier.fillMaxWidth().weight(1f),
+          horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          KeyboardKey(
+            if (symbols) "ABC" else "?123",
+            { symbols = !symbols },
+            Modifier.weight(1.5f).fillMaxHeight(),
+            description = if (symbols) "Letters" else "Numbers and symbols",
+          )
+          KeyboardKey(",", { type(",") }, Modifier.weight(1f).fillMaxHeight())
+          KeyboardKey(
+            spaceShortcutLabel?.let { "Search $it" } ?: "space",
+            { type(" ") },
+            Modifier.weight(4f).fillMaxHeight(),
+            description = spaceShortcutLabel?.let { "Space: activate $it search" } ?: "Space",
+            selected = spaceShortcutLabel != null,
+            icon = spaceShortcutIcon,
+            showLabelWithIcon = true,
+          )
+          KeyboardKey(".", { type(".") }, Modifier.weight(1f).fillMaxHeight())
+          KeyboardKey(
+            "Go",
+            onGo,
+            Modifier.weight(1.5f).fillMaxHeight(),
+            selected = true,
+            description = goDescription,
+            icon = goIcon,
+          )
+        }
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun KeyboardKey(
+  label: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  description: String = label,
+  selected: Boolean = false,
+  repeat: Boolean = false,
+  onLongClick: (() -> Unit)? = null,
+  hint: KeyboardShortcutHint? = null,
+  symbolHint: String? = null,
+  icon: ImageBitmap? = null,
+  showLabelWithIcon: Boolean = false,
+  alternatives: List<String> = emptyList(),
+  onAlternative: (String) -> Unit = {},
+) {
+  val colors = MaterialTheme.colorScheme
+  val dark = colors.surface.luminance() < colors.onSurface.luminance()
+  // Match SearchChromeBar's 3.dp tonal surface; the keyboard's base surface is a shade darker.
+  val restingColor = if (dark) colors.surfaceColorAtElevation(3.dp) else colors.surfaceVariant
+  val restingContentColor = if (dark) colors.onSurface else colors.onSurfaceVariant
+  var heldSelection by remember { mutableStateOf<Int?>(null) }
+  var gesturePressed by remember { mutableStateOf(false) }
+  var keyCenterX by remember { mutableFloatStateOf(0f) }
+  val density = LocalDensity.current
+  val screenWidthPx = with(density) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
+  val reverse = keyCenterX > screenWidthPx / 2
+  val cellWidth = 36.dp
+  val cellWidthPx = with(density) { cellWidth.toPx() }
+  val popupOffset = with(density) { 52.dp.roundToPx() }
+  val currentAlternative by rememberUpdatedState(onAlternative)
+  val interactions = remember { MutableInteractionSource() }
+  val pressed by interactions.collectIsPressedAsState()
+  val currentClick by rememberUpdatedState(onClick)
+  var repeated by remember { mutableStateOf(false) }
+  LaunchedEffect(pressed, repeat) {
+    if (pressed && repeat) {
+      repeated = false
+      delay(400)
+      while (true) {
+        repeated = true
+        currentClick()
+        delay(65)
+      }
+    }
+  }
+  val keyInput =
+    if (alternatives.isEmpty()) {
+      Modifier.combinedClickable(
+        interactionSource = interactions,
+        indication = null,
+        role = Role.Button,
+        onClick = { if (!repeat || !repeated) onClick() },
+        onLongClick = onLongClick,
+      )
+    } else {
+      Modifier.semantics {
+          role = Role.Button
+          onClick {
+            currentClick()
+            true
+          }
+          customActions =
+            alternatives.map { value ->
+              CustomAccessibilityAction("Insert $value") {
+                currentAlternative(value)
+                true
+              }
+            }
+        }
+        .pointerInput(alternatives, reverse) {
+          awaitEachGesture {
+            val down = awaitFirstDown()
+            down.consume()
+            gesturePressed = true
+            try {
+              val longPress = awaitLongPressOrCancellation(down.id)
+              if (longPress == null) {
+                // A normal release types the letter; consumed/cancelled gestures do not.
+                val release = currentEvent.changes.firstOrNull { it.id == down.id }
+                if (release != null && !release.pressed && !release.isConsumed) {
+                  release.consume()
+                  currentClick()
+                }
+              } else {
+                heldSelection = 0
+                val origin = longPress.position.x
+                val direction = if (reverse) -1 else 1
+                while (true) {
+                  val event = awaitPointerEvent()
+                  val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                  if (change.isConsumed) break
+                  val distance = (change.position.x - origin) * direction
+                  heldSelection =
+                    (distance / cellWidthPx).roundToInt().coerceIn(0, alternatives.lastIndex)
+                  change.consume()
+                  if (!change.pressed) {
+                    currentAlternative(alternatives[heldSelection ?: 0])
+                    break
+                  }
+                }
+              }
+            } finally {
+              heldSelection = null
+              gesturePressed = false
+            }
+          }
+        }
+    }
+  Surface(
+    modifier =
+      modifier
+        .focusProperties { canFocus = false }
+        .onGloballyPositioned { keyCenterX = it.positionInWindow().x + it.size.width / 2f }
+        .semantics { contentDescription = description }
+        .then(keyInput),
+    shape = RoundedCornerShape(6.dp),
+    color =
+      when {
+        (pressed || gesturePressed) -> MaterialTheme.colorScheme.primaryContainer
+        selected -> if (dark) colors.surfaceColorAtElevation(6.dp) else colors.secondaryContainer
+        else -> restingColor
+      },
+    contentColor =
+      when {
+        (pressed || gesturePressed) -> MaterialTheme.colorScheme.onPrimaryContainer
+        selected -> if (dark) colors.onSurface else colors.onSecondaryContainer
+        else -> restingContentColor
+      },
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      heldSelection?.let { selection ->
+        Popup(
+          alignment = if (reverse) Alignment.TopEnd else Alignment.TopStart,
+          offset = IntOffset(0, -popupOffset),
+          properties = PopupProperties(focusable = false),
+        ) {
+          Surface(shape = RoundedCornerShape(8.dp), shadowElevation = 6.dp, color = restingColor) {
+            Row(Modifier.padding(4.dp)) {
+              val indices =
+                if (reverse) alternatives.indices.reversed() else alternatives.indices.toList()
+              indices.forEach { index ->
+                Surface(
+                  modifier =
+                    Modifier.size(width = cellWidth, height = 40.dp).semantics {
+                      contentDescription = "Alternative ${alternatives[index]}"
+                      this.selected = index == selection
+                    },
+                  shape = RoundedCornerShape(4.dp),
+                  color =
+                    if (index == selection) MaterialTheme.colorScheme.primary else restingColor,
+                  contentColor =
+                    if (index == selection) MaterialTheme.colorScheme.onPrimary
+                    else restingContentColor,
+                ) {
+                  Box(contentAlignment = Alignment.Center) {
+                    Text(alternatives[index], fontSize = 20.sp)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (icon != null && showLabelWithIcon) {
+        Row(
+          Modifier.padding(horizontal = 8.dp),
+          horizontalArrangement = Arrangement.spacedBy(6.dp),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Image(bitmap = icon, contentDescription = null, modifier = Modifier.size(24.dp))
+          Text(label, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+      } else if (icon != null) {
+        Image(bitmap = icon, contentDescription = null, modifier = Modifier.size(28.dp))
+      } else {
+        Text(label, fontSize = if (label.length > 2) 14.sp else 20.sp, maxLines = 1)
+      }
+      if (symbolHint != null) {
+        Text(
+          symbolHint,
+          modifier = Modifier.align(Alignment.TopEnd).padding(top = 3.dp, end = 5.dp),
+          fontSize = 9.sp,
+          lineHeight = 10.sp,
+          color = LocalContentColor.current.copy(alpha = 0.65f),
+        )
+      }
+      hint?.icon?.let { bitmap ->
+        Image(
+          bitmap = bitmap,
+          contentDescription = null,
+          modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 3.dp).size(12.dp),
+          alpha = 0.5f,
+        )
+      }
+    }
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/HomeKeyboardEditingTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/HomeKeyboardEditingTest.kt
@@ -1,0 +1,75 @@
+package com.searchlauncher.app.ui
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HomeKeyboardEditingTest {
+  @Test
+  fun spacePreviewRequiresExactAliasAndCaretAtEnd() {
+    val youtube =
+      com.searchlauncher.app.data.SearchShortcut(
+        "youtube",
+        "y",
+        "https://youtube.com/?q=%s",
+        "YouTube",
+      )
+    val multi = youtube.copy(id = "gemini", alias = "gem")
+    val shortcuts = listOf(youtube, multi)
+    assertEquals(youtube, pendingKeyboardShortcut(TextFieldValue("y", TextRange(1)), shortcuts))
+    assertEquals(youtube, pendingKeyboardShortcut(TextFieldValue("Y", TextRange(1)), shortcuts))
+    assertEquals(multi, pendingKeyboardShortcut(TextFieldValue("gem", TextRange(3)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("ge", TextRange(2)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("yellow", TextRange(6)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("y ", TextRange(2)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("y", TextRange(0)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("y", TextRange(0, 1)), shortcuts))
+    assertNull(pendingKeyboardShortcut(TextFieldValue("y", TextRange(1)), emptyList()))
+  }
+
+  @Test
+  fun insertionReplacesReversedSelectionAndClearsComposition() {
+    val before = TextFieldValue("hello world", TextRange(11, 6), TextRange(6, 11))
+    val after = before.insertKeyboardText("Joep")
+    assertEquals("hello Joep", after.text)
+    assertEquals(TextRange(10), after.selection)
+    assertNull(after.composition)
+  }
+
+  @Test
+  fun insertionUsesCursorInsteadOfAppending() {
+    val after = TextFieldValue("cats", TextRange(1)).insertKeyboardText("o")
+    assertEquals("coats", after.text)
+    assertEquals(TextRange(2), after.selection)
+  }
+
+  @Test
+  fun backspaceDeletesSelection() {
+    val after = TextFieldValue("abcdef", TextRange(4, 1)).deleteKeyboardText()
+    assertEquals("aef", after.text)
+    assertEquals(TextRange(1), after.selection)
+  }
+
+  @Test
+  fun backspacePreservesTextAfterCursorAndDeletesWholeEmoji() {
+    val after = TextFieldValue("a😀b", TextRange(3)).deleteKeyboardText()
+    assertEquals("ab", after.text)
+    assertEquals(TextRange(1), after.selection)
+  }
+
+  @Test
+  fun backspaceDeletesCombiningAccentWithLetter() {
+    val after = TextFieldValue("e\u0301", TextRange(2)).deleteKeyboardText()
+    assertEquals("", after.text)
+    assertEquals(TextRange(0), after.selection)
+  }
+
+  @Test
+  fun backspaceAtStartDoesNothing() {
+    val before = TextFieldValue("hello", TextRange(0))
+    assertEquals(before, before.deleteKeyboardText())
+    assertEquals(TextFieldValue(""), TextFieldValue("").deleteKeyboardText())
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/HomeKeyboardPreferenceTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/HomeKeyboardPreferenceTest.kt
@@ -1,0 +1,42 @@
+package com.searchlauncher.app.ui
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.data.Prefs
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class HomeKeyboardPreferenceTest {
+  @Test
+  fun defaultsToBuiltInAndPersistsOptOutInBothStores() = runBlocking {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    context.dataStore.edit { it.remove(PreferencesKeys.BUILT_IN_KEYBOARD) }
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .remove("built_in_keyboard")
+      .commit()
+    assertTrue(HomeKeyboardPreference.cached(context))
+    assertTrue(HomeKeyboardPreference.flow(context).first())
+    try {
+      HomeKeyboardPreference.set(context, false)
+      assertFalse(HomeKeyboardPreference.cached(context))
+      assertFalse(HomeKeyboardPreference.flow(context).first())
+      // Restoring DataStore preferences must also refresh the startup cache.
+      context.dataStore.edit { it[PreferencesKeys.BUILT_IN_KEYBOARD] = true }
+      assertTrue(HomeKeyboardPreference.flow(context).first())
+      assertTrue(HomeKeyboardPreference.cached(context))
+    } finally {
+      HomeKeyboardPreference.set(context, true)
+    }
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/ImeTest.kt
@@ -15,6 +15,22 @@ import org.robolectric.annotation.Config
 class ImeTest {
 
   @Test
+  fun homeKeyboardModeCanSwitchBackToSystemWithoutRecreatingActivity() {
+    val window = activity().window
+    Ime.applyHomeWindowMode(window, true)
+    assertEquals(
+      WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN,
+      window.attributes.softInputMode and WindowManager.LayoutParams.SOFT_INPUT_MASK_STATE,
+    )
+    assertEquals(
+      WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING,
+      window.attributes.softInputMode and WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST,
+    )
+    Ime.applyHomeWindowMode(window, false)
+    assertEquals(Ime.SOFT_INPUT_MODE, window.attributes.softInputMode)
+  }
+
+  @Test
   fun softInputMode_isAlwaysVisibleWithoutResizing() {
     val state = Ime.SOFT_INPUT_MODE and WindowManager.LayoutParams.SOFT_INPUT_MASK_STATE
     val adjust = Ime.SOFT_INPUT_MODE and WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST

--- a/fastlane/metadata/android/en-US/changelogs/267.txt
+++ b/fastlane/metadata/android/en-US/changelogs/267.txt
@@ -1,0 +1,1 @@
+YouTube search opens the YouTube app when it's installed, and falls back to youtube.com in the browser when it isn't.


### PR DESCRIPTION
Home search now renders a built-in keyboard with the search bar instead of waiting for the system keyboard animation. Users can opt out in Settings; browser fields and dialogs keep the system keyboard.

The keyboard follows wallpaper colors, shows subtle colored shortcut tags on letter keys, previews exact shortcut aliases on Space, and displays the selected result's icon on Go. Holding a key for 250 ms highlights a symbol; sliding selects alternatives and releasing commits it. Includes accents, shift/caps lock, repeating backspace, cursor/selection editing, and hardware input. Removes the redundant quick-search button beside Clear.

Prepares v0.0.30 (versionCode 268) and its store changelog. Includes the already-published v0.0.29 version commit and preserves the latest widget sizing, portrait-lock, snippet-indexing, and YouTube launch changes.

Validation: spotlessCheck; 287 unit tests in each of debug and release; assembleDebug and assembleRelease; store metadata check. All 11 keyboard interaction tests pass on the integrated release candidate, including the 250 ms hold behavior. Visual smoke checks were also performed during implementation.
