### PR TITLE
Split keyboard, browser bookmark backups and widget recovery — v0.0.31

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 268
-    versionName = "0.0.30"
+    versionCode = 269
+    versionName = "0.0.31"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/app/src/androidTest/java/com/searchlauncher/app/ui/components/HomeSearchKeyboardTest.kt
+++ b/app/src/androidTest/java/com/searchlauncher/app/ui/components/HomeSearchKeyboardTest.kt
@@ -1,14 +1,18 @@
 package com.searchlauncher.app.ui.components
 
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.moveBy
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -24,6 +28,39 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class HomeSearchKeyboardTest {
   @get:Rule val compose = createComposeRule()
+
+  @Test
+  fun wideKeyboardSplitsAndReturnsToCompactLayoutWhenResized() {
+    val width = mutableStateOf(800.dp)
+    var text = ""
+    compose.setContent {
+      MaterialTheme {
+        HomeSearchKeyboard(
+          { text += it },
+          {},
+          {},
+          Modifier.requiredWidth(width.value).height(243.dp),
+          spaceShortcutLabel = "YouTube",
+        )
+      }
+    }
+    val spaces = compose.onAllNodesWithContentDescription("Space: activate YouTube search")
+    spaces.assertCountEquals(2)
+    val t = compose.onNodeWithText("t").fetchSemanticsNode().boundsInRoot
+    val y = compose.onNodeWithText("y").fetchSemanticsNode().boundsInRoot
+    assertTrue(y.left - t.right > t.width)
+    spaces[0].performClick()
+    spaces[1].performClick()
+    compose.onNodeWithText("q").performClick()
+    compose.onNodeWithText("p").performClick()
+    compose.runOnIdle { assertEquals("  qp", text) }
+    compose.onNodeWithContentDescription("Numbers and symbols").performClick()
+    compose.onNodeWithText("1").performClick()
+    compose.onNodeWithText("0").performClick()
+    compose.runOnIdle { assertEquals("  qp10", text) }
+    compose.runOnIdle { width.value = 400.dp }
+    spaces.assertCountEquals(1)
+  }
 
   private fun holdKey(key: String) {
     compose.onNodeWithText(key).performTouchInput {

--- a/app/src/main/java/com/searchlauncher/app/data/BackupManager.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/BackupManager.kt
@@ -1,5 +1,6 @@
 package com.searchlauncher.app.data
 
+import android.content.ComponentName
 import android.content.Context
 import androidx.datastore.preferences.core.edit
 import com.searchlauncher.app.ui.dataStore
@@ -19,22 +20,34 @@ class BackupManager(
   private val historyRepository: HistoryRepository,
   private val wallpaperRepository: WallpaperRepository,
   private val widgetRepository: WidgetRepository,
+  private val searchRepository: SearchRepository,
 ) {
   companion object {
-    const val BACKUP_VERSION = 2 // Bumped version for new format
+    const val BACKUP_VERSION = 4
     private const val MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB limit
+    private val WIDGET_DATASTORE_KEYS = setOf("widgets_data", "widget_ids")
   }
 
   suspend fun exportBackup(outputStream: OutputStream, includeWallpapers: Boolean): Result<Int> =
     withContext(Dispatchers.IO) {
       try {
         android.util.Log.d("BackupManager", "Starting export...")
+        val bookmarks = searchRepository.exportBookmarks()
         // Using BufferedWriter and JsonWriter for memory efficiency
         android.util.JsonWriter(outputStream.writer().buffered()).use { writer ->
           writer.setIndent("  ")
           writer.beginObject()
 
           writer.name("version").value(BACKUP_VERSION)
+
+          writer.name("bookmarks").beginArray()
+          bookmarks.forEach { bookmark ->
+            writer.beginObject()
+            writer.name("url").value(bookmark.url)
+            writer.name("title").value(bookmark.title)
+            writer.endObject()
+          }
+          writer.endArray()
 
           // 1. Export Snippets
           android.util.Log.d("BackupManager", "Exporting Snippets...")
@@ -136,10 +149,15 @@ class BackupManager(
           var widgetsCount = 0
           // Fetch widgets before writing
           val widgetsList = widgetRepository.widgets.first()
+          val appWidgetManager = android.appwidget.AppWidgetManager.getInstance(context)
           widgetsList.forEach { widget ->
             writer.beginObject()
             writer.name("id").value(widget.id)
             widget.height?.let { writer.name("height").value(it) }
+            val provider =
+              widget.provider
+                ?: appWidgetManager.getAppWidgetInfo(widget.id)?.provider?.flattenToString()
+            provider?.let { writer.name("provider").value(it) }
             writer.endObject()
             widgetsCount++
           }
@@ -154,6 +172,7 @@ class BackupManager(
           prefs.asMap().forEach { entry ->
             val key = entry.key
             val value = entry.value
+            if (key.name in WIDGET_DATASTORE_KEYS) return@forEach
             when (value) {
               is String -> {
                 writer.name(key.name).value(value)
@@ -186,7 +205,8 @@ class BackupManager(
           writer.endObject() // End root object
 
           val totalItems =
-            snippetsCount +
+            bookmarks.size +
+              snippetsCount +
               shortcutsCount +
               favoritesCount +
               historyCount +
@@ -216,6 +236,25 @@ class BackupManager(
               "Backup file version ($version) is newer than supported version ($BACKUP_VERSION)"
             )
           )
+        }
+
+        // Validate bookmarks before changing any existing data. Missing means an older backup.
+        val bookmarks =
+          backupData.optJSONArray("bookmarks")?.let { entries ->
+            List(entries.length()) { index ->
+              val entry = entries.getJSONObject(index)
+              val url = entry.getString("url").trim()
+              require(url.isNotEmpty()) { "Bookmark URL is empty" }
+              SearchRepository.SavedBookmark(url, entry.getString("title"))
+            }
+          }
+        if (backupData.has("bookmarks")) requireNotNull(bookmarks) { "Invalid bookmarks section" }
+        var bookmarksCount = 0
+        bookmarks?.forEach { bookmark ->
+          check(searchRepository.saveBookmark(bookmark.url, bookmark.title)) {
+            "Could not restore bookmark: ${bookmark.title}"
+          }
+          bookmarksCount++
         }
 
         var snippetsCount = 0
@@ -313,16 +352,47 @@ class BackupManager(
         // 6. Import Widgets
         if (backupData.has("widgets")) {
           val widgetsArray = backupData.getJSONArray("widgets")
-          widgetRepository.clearAllWidgets()
+          val restoredWidgets = mutableListOf<WidgetData>()
+          val appWidgetManager = android.appwidget.AppWidgetManager.getInstance(context)
+          val appWidgetHost =
+            android.appwidget.AppWidgetHost(context, WidgetRepository.APPWIDGET_HOST_ID)
           for (i in 0 until widgetsArray.length()) {
             val obj = widgetsArray.getJSONObject(i)
-            val id = obj.getInt("id")
-            widgetRepository.addWidgetId(id)
-            if (obj.has("height")) {
-              widgetRepository.updateWidgetHeight(id, obj.getInt("height"))
+            val oldId = obj.getInt("id")
+            val height = if (obj.has("height")) obj.getInt("height") else null
+            val providerName = obj.optString("provider").takeIf { it.isNotEmpty() }
+            var restoredId = oldId
+            val oldProvider = appWidgetManager.getAppWidgetInfo(oldId)?.provider?.flattenToString()
+
+            if (providerName != null && oldProvider != providerName) {
+              val provider = ComponentName.unflattenFromString(providerName)
+              val providerInfo =
+                provider?.let { component ->
+                  appWidgetManager.installedProviders.find { it.provider == component }
+                }
+              // Widgets with configuration must go through their activity. Leave those as a
+              // recoverable placeholder so one tap can bind and configure them correctly.
+              if (providerInfo != null && providerInfo.configure == null) {
+                val newId = appWidgetHost.allocateAppWidgetId()
+                val bound =
+                  try {
+                    appWidgetManager.bindAppWidgetIdIfAllowed(newId, providerInfo.provider)
+                  } catch (e: RuntimeException) {
+                    android.util.Log.w("BackupManager", "Could not restore $providerName", e)
+                    false
+                  }
+                if (bound) {
+                  restoredId = newId
+                } else {
+                  appWidgetHost.deleteAppWidgetId(newId)
+                }
+              }
             }
+
+            restoredWidgets += WidgetData(restoredId, height, providerName)
             widgetsCount++
           }
+          widgetRepository.replaceAll(restoredWidgets)
         }
 
         // 7. Import Settings
@@ -330,6 +400,7 @@ class BackupManager(
           val settingsObj = backupData.getJSONObject("settings")
           context.dataStore.edit { prefs ->
             settingsObj.keys().forEach { keyName ->
+              if (keyName in WIDGET_DATASTORE_KEYS) return@forEach
               val value = settingsObj.get(keyName)
               when (value) {
                 is String ->
@@ -351,6 +422,7 @@ class BackupManager(
 
         Result.success(
           ImportStats(
+            bookmarksCount = bookmarksCount,
             snippetsCount = snippetsCount,
             shortcutsCount = shortcutsCount,
             favoritesCount = favoritesCount,
@@ -367,6 +439,7 @@ class BackupManager(
     }
 
   data class ImportStats(
+    val bookmarksCount: Int,
     val snippetsCount: Int,
     val shortcutsCount: Int,
     val favoritesCount: Int,

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -1456,6 +1456,36 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
     }
 
+  data class SavedBookmark(val url: String, val title: String)
+
+  /** Read durable bookmarks, including entries not yet loaded into the search snapshot. */
+  suspend fun exportBookmarks(): List<SavedBookmark> =
+    withContext(Dispatchers.IO) {
+      val session = checkNotNull(appSearchSession) { "Search is still starting; try again shortly" }
+      val results =
+        session.search("", SearchSpec.Builder().addFilterNamespaces("web_saved").build())
+      try {
+        val bookmarks = mutableListOf<SavedBookmark>()
+        var page = results.nextPageAsync.await()
+        while (page.isNotEmpty()) {
+          page.forEach {
+            val doc = it.genericDocument.toDocumentClass(AppSearchDocument::class.java)
+            bookmarks +=
+              SavedBookmark(
+                doc.description.orEmpty().ifBlank {
+                  requireNotNull(doc.intentUri) { "Bookmark has no URL" }
+                },
+                doc.name,
+              )
+          }
+          page = results.nextPageAsync.await()
+        }
+        bookmarks
+      } finally {
+        results.close()
+      }
+    }
+
   /**
    * Explicitly bookmarks a page from the browser. Unlike [indexWebUrl] this ignores the
    * store-web-history preference (it's a deliberate user action, not passive tracking) and lands in

--- a/app/src/main/java/com/searchlauncher/app/data/WidgetRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/WidgetRepository.kt
@@ -9,9 +9,14 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 
-@kotlinx.serialization.Serializable data class WidgetData(val id: Int, val height: Int? = null)
+@kotlinx.serialization.Serializable
+data class WidgetData(val id: Int, val height: Int? = null, val provider: String? = null)
 
 class WidgetRepository(private val context: Context) {
+  companion object {
+    const val APPWIDGET_HOST_ID = 1002
+  }
+
   private val WIDGETS_KEY = stringPreferencesKey("widgets_data")
   // Legacy key for migration
   private val WIDGET_IDS_KEY = stringPreferencesKey("widget_ids")
@@ -29,6 +34,7 @@ class WidgetRepository(private val context: Context) {
               WidgetData(
                 id = obj.getInt("id"),
                 height = if (obj.has("height")) obj.getInt("height") else null,
+                provider = obj.optString("provider").takeIf { it.isNotEmpty() },
               )
             )
           }
@@ -59,6 +65,7 @@ class WidgetRepository(private val context: Context) {
         val obj = org.json.JSONObject()
         obj.put("id", item.id)
         item.height?.let { obj.put("height", it) }
+        item.provider?.let { obj.put("provider", it) }
         jsonArray.put(obj)
       }
       preferences[WIDGETS_KEY] = jsonArray.toString()
@@ -79,6 +86,23 @@ class WidgetRepository(private val context: Context) {
     val current = widgets.first()
     val newList = current.filter { it.id != appWidgetId }
     saveWidgets(newList)
+  }
+
+  suspend fun replaceWidgetId(oldAppWidgetId: Int, newAppWidgetId: Int, provider: String? = null) {
+    val current = widgets.first()
+    val newList =
+      current.map {
+        if (it.id == oldAppWidgetId) {
+          it.copy(id = newAppWidgetId, provider = provider ?: it.provider)
+        } else {
+          it
+        }
+      }
+    saveWidgets(newList)
+  }
+
+  suspend fun replaceAll(widgets: List<WidgetData>) {
+    saveWidgets(widgets)
   }
 
   suspend fun clearAllWidgets() {

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -29,6 +29,8 @@ import androidx.lifecycle.lifecycleScope
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.WidgetData
+import com.searchlauncher.app.data.WidgetRepository
 import com.searchlauncher.app.ui.theme.SearchLauncherTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -83,7 +85,6 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
 
   lateinit var appWidgetManager: android.appwidget.AppWidgetManager
   lateinit var appWidgetHost: android.appwidget.AppWidgetHost
-  private val APPWIDGET_HOST_ID = 1002
   private val REQUEST_CONFIGURE_APPWIDGET = 10
 
   private val pickWallpapersLauncher =
@@ -117,6 +118,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     }
 
   private var pendingAppWidgetId = -1
+  private var pendingReplacementWidgetId = -1
 
   private val bindWidgetLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -183,23 +185,39 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           } else {
             android.util.Log.e("MainActivity", "Widget $appWidgetId NOT bound.")
             appWidgetHost.deleteAppWidgetId(appWidgetId)
+            pendingReplacementWidgetId = -1
             // Only show error if we really expected it to work (OK result) or user cancelled
             if (result.resultCode == RESULT_OK) {
               Toast.makeText(this, "Binding verification failed.", Toast.LENGTH_SHORT).show()
             }
           }
         } else {
+          pendingReplacementWidgetId = -1
           Toast.makeText(this, "Binding failed (No ID).", Toast.LENGTH_SHORT).show()
         }
       } else {
         // Explicit cancellation with no recovered ID (unlikely if pending logic works)
         android.util.Log.d("MainActivity", "bindWidgetLauncher cancelled/failed")
+        pendingReplacementWidgetId = -1
       }
     }
 
   fun requestWidgetPick() {
     updateQueryState("widgets ")
     focusTrigger = System.currentTimeMillis()
+  }
+
+  fun requestWidgetReplacement(widget: WidgetData) {
+    pendingReplacementWidgetId = widget.id
+    val provider =
+      widget.provider?.let(android.content.ComponentName::unflattenFromString)?.let { component ->
+        appWidgetManager.installedProviders.find { it.provider == component }
+      }
+    if (provider != null) {
+      onWidgetProviderSelected(provider)
+    } else {
+      showWidgetPicker.value = true
+    }
   }
 
   private fun onWidgetProviderSelected(providerInfo: android.appwidget.AppWidgetProviderInfo) {
@@ -216,6 +234,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
           providerInfo.provider,
         )
+        pendingAppWidgetId = appWidgetId
         bindWidgetLauncher.launch(intent)
       }
     } catch (e: SecurityException) {
@@ -240,6 +259,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           bindWidgetLauncher.launch(intent)
         } catch (innerE: Exception) {
           android.util.Log.e("MainActivity", "Fallback failed", innerE)
+          pendingReplacementWidgetId = -1
           Toast.makeText(
               this,
               "Permission denied. Enable 'Restricted Settings' in App Info, then FORCE STOP the app.",
@@ -248,10 +268,12 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
             .show()
         }
       } else {
+        pendingReplacementWidgetId = -1
         Toast.makeText(this, "Allocation failed due to restriction.", Toast.LENGTH_SHORT).show()
       }
     } catch (e: Exception) {
       android.util.Log.e("MainActivity", "Error adding widget", e)
+      pendingReplacementWidgetId = -1
       Toast.makeText(this, "Error adding widget: ${e.message}", Toast.LENGTH_SHORT).show()
     }
     showWidgetPicker.value = false
@@ -265,7 +287,16 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
 
   private fun persistAddedWidget(appWidgetId: Int) {
     lifecycleScope.launch {
-      (application as SearchLauncherApp).widgetRepository.addWidgetId(appWidgetId)
+      val repository = (application as SearchLauncherApp).widgetRepository
+      val replacementId = pendingReplacementWidgetId
+      if (replacementId != -1) {
+        val provider = appWidgetManager.getAppWidgetInfo(appWidgetId)?.provider?.flattenToString()
+        repository.replaceWidgetId(replacementId, appWidgetId, provider)
+        appWidgetHost.deleteAppWidgetId(replacementId)
+        pendingReplacementWidgetId = -1
+      } else {
+        repository.addWidgetId(appWidgetId)
+      }
       dataStore.edit { prefs -> prefs[PreferencesKeys.SHOW_WIDGETS] = true }
     }
   }
@@ -469,7 +500,8 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     appWidgetManager = android.appwidget.AppWidgetManager.getInstance(applicationContext)
-    appWidgetHost = android.appwidget.AppWidgetHost(applicationContext, APPWIDGET_HOST_ID)
+    appWidgetHost =
+      android.appwidget.AppWidgetHost(applicationContext, WidgetRepository.APPWIDGET_HOST_ID)
     queryState = savedInstanceState?.getString(KEY_ACTIVE_QUERY) ?: restoreRecentQuery()
     enableEdgeToEdge()
     Ime.applyHomeWindowMode(window, HomeKeyboardPreference.cached(this))
@@ -650,6 +682,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           "Widget $appWidgetId configuration cancelled, deleting ID",
         )
         appWidgetHost.deleteAppWidgetId(appWidgetId)
+        pendingReplacementWidgetId = -1
       }
     }
   }
@@ -1016,7 +1049,10 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
       WidgetPicker(
         appWidgetManager = appWidgetManager,
         onWidgetSelected = { info -> onWidgetProviderSelected(info) },
-        onDismiss = { showWidgetPicker.value = false },
+        onDismiss = {
+          pendingReplacementWidgetId = -1
+          showWidgetPicker.value = false
+        },
       )
     }
   }
@@ -1057,6 +1093,7 @@ private fun MainActivity.createBackupManager(): com.searchlauncher.app.data.Back
     historyRepository = app.historyRepository,
     wallpaperRepository = app.wallpaperRepository,
     widgetRepository = app.widgetRepository,
+    searchRepository = app.searchRepository,
   )
 }
 
@@ -1141,7 +1178,7 @@ private suspend fun MainActivity.performImport(uri: android.net.Uri) {
           if (result.isSuccess) {
             android.widget.Toast.makeText(
                 this@performImport,
-                "Import successful!",
+                "Import successful! ${result.getOrThrow().bookmarksCount} bookmarks restored.",
                 android.widget.Toast.LENGTH_LONG,
               )
               .show()

--- a/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt
@@ -1379,7 +1379,7 @@ private fun BackupRestoreCard(onExportBackup: () -> Unit) {
       Text(text = "Backup & Restore", style = MaterialTheme.typography.titleMedium)
       Text(
         text =
-          "Export all your data (Snippets, Shortcuts, Favorites, Background) to a .searchlauncher file",
+          "Export settings, snippets, shortcuts, favorites, browser bookmarks, widgets and optional backgrounds to a .searchlauncher file",
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )

--- a/app/src/main/java/com/searchlauncher/app/ui/components/HomeSearchKeyboard.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/HomeSearchKeyboard.kt
@@ -96,113 +96,142 @@ fun HomeSearchKeyboard(
       color = MaterialTheme.colorScheme.surface,
       contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
-      Column(
-        Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(5.dp),
-      ) {
-        val rows =
-          if (!symbols) listOf("qwertyuiop", "asdfghjkl", "zxcvbnm")
-          else if (!extraSymbols) listOf("1234567890", "@#€%&-+()", "*\"':;!?/")
-          else listOf("~`|•√π÷×§∆", "£¢$^°={}\\", "_[]<>:,.")
-        rows.forEachIndexed { index, letters ->
+      BoxWithConstraints {
+        val split = maxWidth >= 600.dp
+        val splitGap = maxOf(48.dp, maxWidth - 640.dp)
+        Column(
+          Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+          verticalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+          val rows =
+            if (!symbols) listOf("qwertyuiop", "asdfghjkl", "zxcvbnm")
+            else if (!extraSymbols) listOf("1234567890", "@#€%&-+()", "*\"':;!?/")
+            else listOf("~`|•√π÷×§∆", "£¢$^°={}\\", "_[]<>:,.")
+          rows.forEachIndexed { index, letters ->
+            Row(
+              Modifier.fillMaxWidth().weight(1f),
+              horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+              val splitAt = if (index == 2) 4 else 5
+              val groups =
+                if (split) listOf(letters.take(splitAt), letters.drop(splitAt)) else listOf(letters)
+              groups.forEachIndexed { half, keys ->
+                if (half == 1) Spacer(Modifier.width(splitGap))
+                Row(
+                  Modifier.weight(1f).fillMaxHeight(),
+                  horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                  if (index == 1 && !split) Spacer(Modifier.weight(0.5f))
+                  if (index == 2 && half == 0) {
+                    KeyboardKey(
+                      label = if (symbols) "=\\<" else if (capsLock) "⇪" else "⇧",
+                      description =
+                        if (symbols) "More symbols" else if (capsLock) "Caps lock on" else "Shift",
+                      modifier = Modifier.weight(1.4f).fillMaxHeight(),
+                      selected = shift || capsLock,
+                      onClick = {
+                        if (symbols) extraSymbols = !extraSymbols
+                        else {
+                          shift = !shift
+                          capsLock = false
+                        }
+                      },
+                      onLongClick =
+                        if (symbols) null
+                        else
+                          ({
+                            capsLock = !capsLock
+                            shift = capsLock
+                          }),
+                    )
+                  }
+                  keys.forEach { letter ->
+                    val symbolHint = if (symbols) null else keySymbols[letter]
+                    val alternatives =
+                      if (symbols) emptyList()
+                      else
+                        buildList {
+                          symbolHint?.let { add(it) }
+                          // Related bracket styles stay together without needing another keyboard
+                          // page.
+                          if (letter == 'k') addAll("[{".toList())
+                          if (letter == 'l') addAll("]}".toList())
+                          addAll(accents[letter].orEmpty().toList())
+                        }
+                    Box(Modifier.weight(1f).fillMaxHeight()) {
+                      KeyboardKey(
+                        label = if (shift || capsLock) letter.uppercase() else letter.toString(),
+                        modifier = Modifier.fillMaxSize(),
+                        symbolHint = symbolHint?.toString(),
+                        description =
+                          shortcutHints[letter]
+                            ?.takeIf { !symbols }
+                            ?.let { "$letter, ${it.label} shortcut" }
+                            ?: if (shift || capsLock) letter.uppercase() else letter.toString(),
+                        onClick = { type(letter.toString()) },
+                        alternatives =
+                          alternatives.map {
+                            if (shift || capsLock) it.uppercase() else it.toString()
+                          },
+                        onAlternative = { type(it) },
+                      )
+                    }
+                  }
+                  if (index == 1 && !split) Spacer(Modifier.weight(0.5f))
+                  if (index == 2 && (!split || half == 1))
+                    KeyboardKey(
+                      "⌫",
+                      onBackspace,
+                      Modifier.weight(1.4f).fillMaxHeight(),
+                      description = "Backspace",
+                      repeat = true,
+                    )
+                }
+              }
+            }
+          }
           Row(
             Modifier.fillMaxWidth().weight(1f),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
           ) {
-            if (index == 1) Spacer(Modifier.weight(0.5f))
-            if (index == 2) {
-              KeyboardKey(
-                label = if (symbols) "=\\<" else if (capsLock) "⇪" else "⇧",
-                description =
-                  if (symbols) "More symbols" else if (capsLock) "Caps lock on" else "Shift",
-                modifier = Modifier.weight(1.4f).fillMaxHeight(),
-                selected = shift || capsLock,
-                onClick = {
-                  if (symbols) extraSymbols = !extraSymbols
-                  else {
-                    shift = !shift
-                    capsLock = false
-                  }
-                },
-                onLongClick =
-                  if (symbols) null
-                  else
-                    ({
-                      capsLock = !capsLock
-                      shift = capsLock
-                    }),
-              )
-            }
-            letters.forEach { letter ->
-              val symbolHint = if (symbols) null else keySymbols[letter]
-              val alternatives =
-                if (symbols) emptyList()
-                else
-                  buildList {
-                    symbolHint?.let { add(it) }
-                    // Related bracket styles stay together without needing another keyboard page.
-                    if (letter == 'k') addAll("[{".toList())
-                    if (letter == 'l') addAll("]}".toList())
-                    addAll(accents[letter].orEmpty().toList())
-                  }
-              Box(Modifier.weight(1f).fillMaxHeight()) {
+            repeat(if (split) 2 else 1) { half ->
+              if (half == 1) Spacer(Modifier.width(splitGap))
+              Row(
+                Modifier.weight(1f).fillMaxHeight(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+              ) {
+                if (half == 0) {
+                  KeyboardKey(
+                    if (symbols) "ABC" else "?123",
+                    { symbols = !symbols },
+                    Modifier.weight(1.5f).fillMaxHeight(),
+                    description = if (symbols) "Letters" else "Numbers and symbols",
+                  )
+                  KeyboardKey(",", { type(",") }, Modifier.weight(1f).fillMaxHeight())
+                }
                 KeyboardKey(
-                  label = if (shift || capsLock) letter.uppercase() else letter.toString(),
-                  modifier = Modifier.fillMaxSize(),
-                  hint = if (symbols) null else shortcutHints[letter],
-                  symbolHint = symbolHint?.toString(),
-                  description =
-                    shortcutHints[letter]
-                      ?.takeIf { !symbols }
-                      ?.let { "$letter, ${it.label} shortcut" }
-                      ?: if (shift || capsLock) letter.uppercase() else letter.toString(),
-                  onClick = { type(letter.toString()) },
-                  alternatives =
-                    alternatives.map { if (shift || capsLock) it.uppercase() else it.toString() },
-                  onAlternative = { type(it) },
+                  spaceShortcutLabel?.let { "Search $it" } ?: "space",
+                  { type(" ") },
+                  Modifier.weight(if (split) 3f else 4f).fillMaxHeight(),
+                  description = spaceShortcutLabel?.let { "Space: activate $it search" } ?: "Space",
+                  selected = spaceShortcutLabel != null,
+                  icon = spaceShortcutIcon,
+                  showLabelWithIcon = true,
                 )
+                if (!split || half == 1) {
+                  KeyboardKey(".", { type(".") }, Modifier.weight(1f).fillMaxHeight())
+                  KeyboardKey(
+                    "Go",
+                    onGo,
+                    Modifier.weight(1.5f).fillMaxHeight(),
+                    selected = true,
+                    description = goDescription,
+                    icon = goIcon,
+                  )
+                }
               }
             }
-            if (index == 1) Spacer(Modifier.weight(0.5f))
-            if (index == 2)
-              KeyboardKey(
-                "⌫",
-                onBackspace,
-                Modifier.weight(1.4f).fillMaxHeight(),
-                description = "Backspace",
-                repeat = true,
-              )
           }
-        }
-        Row(
-          Modifier.fillMaxWidth().weight(1f),
-          horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-          KeyboardKey(
-            if (symbols) "ABC" else "?123",
-            { symbols = !symbols },
-            Modifier.weight(1.5f).fillMaxHeight(),
-            description = if (symbols) "Letters" else "Numbers and symbols",
-          )
-          KeyboardKey(",", { type(",") }, Modifier.weight(1f).fillMaxHeight())
-          KeyboardKey(
-            spaceShortcutLabel?.let { "Search $it" } ?: "space",
-            { type(" ") },
-            Modifier.weight(4f).fillMaxHeight(),
-            description = spaceShortcutLabel?.let { "Space: activate $it search" } ?: "Space",
-            selected = spaceShortcutLabel != null,
-            icon = spaceShortcutIcon,
-            showLabelWithIcon = true,
-          )
-          KeyboardKey(".", { type(".") }, Modifier.weight(1f).fillMaxHeight())
-          KeyboardKey(
-            "Go",
-            onGo,
-            Modifier.weight(1.5f).fillMaxHeight(),
-            selected = true,
-            description = goDescription,
-            icon = goIcon,
-          )
         }
       }
     }
@@ -219,7 +248,6 @@ private fun KeyboardKey(
   selected: Boolean = false,
   repeat: Boolean = false,
   onLongClick: (() -> Unit)? = null,
-  hint: KeyboardShortcutHint? = null,
   symbolHint: String? = null,
   icon: ImageBitmap? = null,
   showLabelWithIcon: Boolean = false,
@@ -396,14 +424,6 @@ private fun KeyboardKey(
           fontSize = 9.sp,
           lineHeight = 10.sp,
           color = LocalContentColor.current.copy(alpha = 0.65f),
-        )
-      }
-      hint?.icon?.let { bitmap ->
-        Image(
-          bitmap = bitmap,
-          contentDescription = null,
-          modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 3.dp).size(12.dp),
-          alpha = 0.5f,
         )
       }
     }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
@@ -450,6 +450,7 @@ fun WallpaperBackground(
 
                         if (!canRender) {
                           MissingWidget(
+                            onReplace = { activity?.requestWidgetReplacement(widget) },
                             onRemove = {
                               scope.launch {
                                 app.widgetRepository.removeWidgetId(widget.id)
@@ -585,17 +586,22 @@ fun WallpaperBackground(
  * Stands in for a widget the host cannot draw, most often one whose id came back from a backup and
  * no longer belongs to anything.
  *
- * It exists because the alternative was worse: an empty view still claimed the widget's space, so
- * the home screen had a silent gap in it and no way to work out what was wrong or clear it. This
- * says what happened and offers the removal, since the widget cannot be recovered — the id is gone,
- * and rebinding one needs a provider this launcher never stored.
+ * It exists because an empty view still claims the widget's space and leaves no clue how to
+ * recover. New backups retain the provider, so tapping the card can reconnect it directly; older
+ * backups fall back to the widget picker. Removal remains available when the provider app is
+ * actually gone.
  */
 @Composable
-private fun MissingWidget(onRemove: () -> Unit, modifier: Modifier = Modifier) {
+private fun MissingWidget(
+  onReplace: () -> Unit,
+  onRemove: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
   Box(
     modifier =
       modifier
         .padding(horizontal = 16.dp)
+        .clickable(onClick = onReplace)
         .background(
           MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.85f),
           RoundedCornerShape(16.dp),
@@ -619,11 +625,14 @@ private fun MissingWidget(onRemove: () -> Unit, modifier: Modifier = Modifier) {
       }
       Text(
         text =
-          "Its app is gone, or it was restored from a backup. Widgets cannot be restored, so this " +
-            "one has to be added again.",
+          "Its binding could not be restored automatically. Replace it to reconnect the same " +
+            "widget or choose another one.",
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onErrorContainer,
       )
+      TextButton(onClick = onReplace, contentPadding = PaddingValues(0.dp)) {
+        Text(text = "Replace", color = MaterialTheme.colorScheme.onErrorContainer)
+      }
       TextButton(onClick = onRemove, contentPadding = PaddingValues(0.dp)) {
         Text(text = "Remove", color = MaterialTheme.colorScheme.onErrorContainer)
       }

--- a/app/src/test/java/com/searchlauncher/app/data/BackupManagerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/BackupManagerTest.kt
@@ -1,0 +1,89 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class BackupManagerTest {
+  private val search = mockk<SearchRepository>()
+  private val snippets = mockk<SnippetsRepository>(relaxed = true)
+  private val shortcuts = mockk<SearchShortcutRepository>(relaxed = true)
+  private val history = mockk<HistoryRepository>(relaxed = true)
+  private val wallpapers = mockk<WallpaperRepository>(relaxed = true)
+  private val widgets = mockk<WidgetRepository>(relaxed = true)
+
+  private fun manager(): BackupManager {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val favorites = FavoritesRepository(context)
+    every { snippets.items } returns MutableStateFlow(emptyList())
+    every { shortcuts.items } returns MutableStateFlow(emptyList())
+    every { history.historyIds } returns MutableStateFlow(emptyList())
+    every { widgets.widgets } returns MutableStateFlow(emptyList())
+    return BackupManager(
+      context,
+      snippets,
+      shortcuts,
+      favorites,
+      history,
+      wallpapers,
+      widgets,
+      search,
+    )
+  }
+
+  @Test
+  fun `bookmarks round trip with exact URLs and titles`() = runBlocking {
+    val bookmark =
+      SearchRepository.SavedBookmark("https://example.com/?q=a&b=2", "A \"title\" — café")
+    coEvery { search.exportBookmarks() } returns listOf(bookmark)
+    coEvery { search.saveBookmark(bookmark.url, bookmark.title) } returns true
+    val backup = manager()
+    val output = ByteArrayOutputStream()
+    backup.exportBackup(output, false).getOrThrow()
+    val json = JSONObject(output.toString("UTF-8"))
+    assertEquals(4, json.getInt("version"))
+    assertEquals(bookmark.url, json.getJSONArray("bookmarks").getJSONObject(0).getString("url"))
+    val restored = backup.importBackup(output.toByteArray().inputStream()).getOrThrow()
+    assertEquals(1, restored.bookmarksCount)
+    coVerify(exactly = 1) { search.saveBookmark(bookmark.url, bookmark.title) }
+  }
+
+  @Test
+  fun `older backups leave bookmarks untouched`() = runBlocking {
+    assertEquals(
+      0,
+      manager().importBackup("""{"version":3}""".byteInputStream()).getOrThrow().bookmarksCount,
+    )
+    coVerify(exactly = 0) { search.saveBookmark(any(), any()) }
+  }
+
+  @Test
+  fun `invalid bookmarks are rejected before any bookmark is saved`() = runBlocking {
+    val json =
+      """{"version":4,"bookmarks":[{"url":"https://example.com","title":"Good"},{"url":"","title":"Bad"}]}"""
+    assertTrue(manager().importBackup(json.byteInputStream()).isFailure)
+    coVerify(exactly = 0) { search.saveBookmark(any(), any()) }
+  }
+
+  @Test
+  fun `failed storage is reported as an import failure`() = runBlocking {
+    coEvery { search.saveBookmark(any(), any()) } returns false
+    val json = """{"version":4,"bookmarks":[{"url":"https://example.com","title":"Example"}]}"""
+    assertTrue(manager().importBackup(json.byteInputStream()).isFailure)
+  }
+}

--- a/fastlane/metadata/android/en-US/changelogs/269.txt
+++ b/fastlane/metadata/android/en-US/changelogs/269.txt
@@ -1,0 +1,1 @@
+The home keyboard splits on wide screens, with a shortcut-preview spacebar on each side. Removed shortcut icons from letter keys. Backups now include browser bookmark URLs and titles, and imports merge them with existing bookmarks. Widget backups retain their provider and offer replacement when automatic restore is unavailable. Contact icons in favorites are now round.


### PR DESCRIPTION
The home keyboard now splits into two edge-aligned halves at 600 dp, with a shortcut-preview spacebar on each half. Letter-key shortcut icons are removed while the spacebar preview remains.

Backups include saved browser bookmark URLs and titles. Import merges bookmarks with existing saves; older backups leave them untouched. Widget backups preserve provider information, attempt rebinding where possible, and offer a replacement action when manual recovery is needed. Raw widget settings are excluded so they cannot overwrite restored bindings.

Prepares v0.0.31 (versionCode 269). The release also includes the rounded favorite-contact icons already on main.

Validation: bookmark round-trip, old-backup, malformed-input and failed-storage tests pass. All 291 unit tests pass in both debug and release, as do spotlessCheck, store metadata validation, and both builds. All 12 keyboard instrumentation tests pass on the release candidate, including split layout, both spacebars, and resizing to compact width.
