### PR TITLE
Fix repeated wallpaper theme updates and widget size reporting

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/WidgetHostViewFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/WidgetHostViewFactory.kt
@@ -35,6 +35,26 @@ object WidgetHostViewFactory {
       val hostView = appWidgetHost.createView(context, appWidgetId, appWidgetInfo)
       hostView.setAppWidget(appWidgetId, appWidgetInfo)
 
+      // Responsive/list providers need the actual allocated size, including after a resize.
+      // Post outside layout and coalesce changes so provider updates cannot re-enter measurement.
+      var reportedSize: Pair<Int, Int>? = null
+      val reportSize = Runnable {
+        val density = hostView.resources.displayMetrics.density
+        val size = (hostView.width / density).toInt() to (hostView.height / density).toInt()
+        if (size.first > 0 && size.second > 0 && size != reportedSize) {
+          try {
+            hostView.updateAppWidgetSize(null, size.first, size.second, size.first, size.second)
+            reportedSize = size
+          } catch (e: Exception) {
+            android.util.Log.w("WidgetHostViewFactory", "Cannot report widget $appWidgetId size", e)
+          }
+        }
+      }
+      hostView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+        hostView.removeCallbacks(reportSize)
+        hostView.post(reportSize)
+      }
+
       // Enforce minimum height (often crucial for list widgets like Calendar).
       //
       // [AppWidgetProviderInfo.minHeight] is already in pixels — the framework resolves the
@@ -49,7 +69,7 @@ object WidgetHostViewFactory {
         hostView,
         FrameLayout.LayoutParams(
           ViewGroup.LayoutParams.MATCH_PARENT,
-          ViewGroup.LayoutParams.WRAP_CONTENT,
+          ViewGroup.LayoutParams.MATCH_PARENT,
         ),
       )
       frameLayout

--- a/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
@@ -149,11 +149,9 @@ private fun WallpaperPager(
         val currentUri = folderImages[page % folderImages.size]
         currentOnPageChanged(currentUri)
 
-        if (currentUri.toString() != lastImageUriString) {
-          context.dataStore.edit { prefs ->
-            prefs[PreferencesKeys.BACKGROUND_LAST_IMAGE_URI] = currentUri.toString()
-          }
-        }
+        // Compare against current storage, not the URI captured when this collector started.
+        // Returning to that initial wallpaper must also update the theme's source URI (#138).
+        persistWallpaperSelection(context.dataStore, currentUri.toString())
       }
   }
 
@@ -749,4 +747,15 @@ internal fun packWidgetsIntoColumns(
     used += if (columns.last().size == 1) height else height + spacing
   }
   return columns
+}
+
+internal suspend fun persistWallpaperSelection(
+  store: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences>,
+  uri: String,
+) {
+  store.edit { prefs ->
+    if (prefs[PreferencesKeys.BACKGROUND_LAST_IMAGE_URI] != uri) {
+      prefs[PreferencesKeys.BACKGROUND_LAST_IMAGE_URI] = uri
+    }
+  }
 }

--- a/app/src/test/java/com/searchlauncher/app/ui/WidgetHostViewFactoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/WidgetHostViewFactoryTest.kt
@@ -63,6 +63,49 @@ class WidgetHostViewFactoryTest {
   }
 
   @Test
+  @Config(qualifiers = "xxhdpi")
+  fun `allocated widget size is reported in dp and follows resizing`() {
+    bind(12, minHeight = 60)
+    val sizes = mutableListOf<Pair<Int, Int>>()
+    val widgetView =
+      object : android.appwidget.AppWidgetHostView(context) {
+        override fun updateAppWidgetSize(
+          options: android.os.Bundle?,
+          minWidth: Int,
+          minHeight: Int,
+          maxWidth: Int,
+          maxHeight: Int,
+        ) {
+          sizes.add(minWidth to minHeight)
+        }
+      }
+    val host = io.mockk.mockk<AppWidgetHost>()
+    io.mockk.every { host.createView(any(), 12, any()) } returns widgetView
+    val view =
+      WidgetHostViewFactory.createWidgetView(context, 12, host, appWidgetManager) as ViewGroup
+    val activity =
+      org.robolectric.Robolectric.buildActivity(android.app.Activity::class.java).setup().get()
+    activity.setContentView(view, ViewGroup.LayoutParams(900, 600))
+    fun layout(height: Int) {
+      view.layoutParams = view.layoutParams.apply { this.height = height }
+      view.measure(
+        android.view.View.MeasureSpec.makeMeasureSpec(900, android.view.View.MeasureSpec.EXACTLY),
+        android.view.View.MeasureSpec.makeMeasureSpec(height, android.view.View.MeasureSpec.EXACTLY),
+      )
+      view.layout(0, 0, 900, height)
+      shadowOf(android.os.Looper.getMainLooper()).idle()
+    }
+    layout(600)
+    val first = sizes.last().second
+    assertTrue(first > 0)
+    assertTrue(first <= 200)
+    layout(900)
+    val second = sizes.last().second
+    assertEquals(100, second - first)
+    activity.finish()
+  }
+
+  @Test
   fun `an id that was never bound cannot be rendered`() {
     // The state an import leaves behind: the id came from a previous install's host, so nothing
     // here answers for it. Rendering it produced an empty view that still took up its space.

--- a/app/src/test/java/com/searchlauncher/app/ui/components/WallpaperSelectionTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/components/WallpaperSelectionTest.kt
@@ -1,0 +1,40 @@
+package com.searchlauncher.app.ui.components
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.searchlauncher.app.ui.PreferencesKeys
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class WallpaperSelectionTest {
+  @get:Rule val folder = TemporaryFolder()
+
+  @Test
+  fun `every wallpaper stays selected across repeated forward and backward cycles`() = runBlocking {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    val store =
+      PreferenceDataStoreFactory.create(scope = scope) {
+        File(folder.root, "wallpaper.preferences_pb")
+      }
+    try {
+      val images = listOf("file:///a.jpg", "file:///b.jpg", "file:///c.jpg", "file:///d.jpg")
+      persistWallpaperSelection(store, images.first())
+      repeat(5) {
+        for (uri in images + images.reversed()) {
+          persistWallpaperSelection(store, uri)
+          assertEquals(uri, store.data.first()[PreferencesKeys.BACKGROUND_LAST_IMAGE_URI])
+        }
+      }
+    } finally {
+      scope.cancel()
+    }
+  }
+}


### PR DESCRIPTION
Returning to the wallpaper that was selected when the pager first opened skipped saving its URI. The theme therefore kept the previous wallpaper's color. The pager now compares with current DataStore state, so repeated forward/backward cycles update the selection correctly. Refs #138.

Widget hosts now fill their allocated height and report their measured size in dp to providers, including after resizing. Updates are coalesced and posted outside layout to avoid re-entering measurement. This addresses a concrete missing size-reporting path relevant to responsive and multi-line widgets. Refs #137; the reported SmartSpacer/ToDo Agenda failure still requires physical-device reproduction and verification.

Validation: spotlessCheck, full debug unit suite, and assembleDebug passed. Added regression coverage for five forward/backward cycles of four wallpapers and widget provider size notifications across resizing on a dense display. No device was connected for visual validation.

The other open issues are outside this patch, including the Samsung floating-window behavior in #109.
