### PR TITLE
Fix empty multi-line list widgets (Smartspacer, ToDo Agenda)

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/WidgetRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/WidgetRepository.kt
@@ -15,6 +15,7 @@ data class WidgetData(val id: Int, val height: Int? = null, val provider: String
 class WidgetRepository(private val context: Context) {
   companion object {
     const val APPWIDGET_HOST_ID = 1002
+    const val DEFAULT_WIDGET_HEIGHT_DP = 200
   }
 
   private val WIDGETS_KEY = stringPreferencesKey("widgets_data")
@@ -78,7 +79,7 @@ class WidgetRepository(private val context: Context) {
 
   suspend fun addWidgetId(appWidgetId: Int) {
     val current = widgets.first()
-    val newList = current + WidgetData(appWidgetId, height = 200)
+    val newList = current + WidgetData(appWidgetId, height = DEFAULT_WIDGET_HEIGHT_DP)
     saveWidgets(newList)
   }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/LauncherAppWidgetHost.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/LauncherAppWidgetHost.kt
@@ -1,0 +1,29 @@
+package com.searchlauncher.app.ui
+
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetHostView
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+
+/**
+ * Hosts home-screen widgets with a view that does not clip collection children.
+ *
+ * List/grid widgets (Smartspacer's multi-line widget, ToDo Agenda) inflate an AdapterView inside
+ * the host. Clipping the host to its padding box, or giving the provider an empty
+ * [android.appwidget.AppWidgetManager.OPTION_APPWIDGET_SIZES] list, leaves that AdapterView with
+ * nothing to draw.
+ */
+class LauncherAppWidgetHost(context: Context, hostId: Int) : AppWidgetHost(context, hostId) {
+  override fun onCreateView(
+    context: Context,
+    appWidgetId: Int,
+    appWidget: AppWidgetProviderInfo?,
+  ): AppWidgetHostView = LauncherAppWidgetHostView(context)
+}
+
+class LauncherAppWidgetHostView(context: Context) : AppWidgetHostView(context) {
+  init {
+    clipChildren = false
+    clipToPadding = false
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -227,7 +227,9 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
     var appWidgetId = -1
     try {
       appWidgetId = appWidgetHost.allocateAppWidgetId()
-      val allowed = appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, providerInfo.provider)
+      val sizeOptions = WidgetHostViewFactory.defaultSizeOptions(this)
+      val allowed =
+        appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, providerInfo.provider, sizeOptions)
       if (allowed) {
         configureWidget(appWidgetId)
       } else {
@@ -237,6 +239,7 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
           providerInfo.provider,
         )
+        intent.putExtra(android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_OPTIONS, sizeOptions)
         pendingAppWidgetId = appWidgetId
         bindWidgetLauncher.launch(intent)
       }
@@ -257,6 +260,10 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
           intent.putExtra(
             android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
             providerInfo.provider,
+          )
+          intent.putExtra(
+            android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_OPTIONS,
+            WidgetHostViewFactory.defaultSizeOptions(this),
           )
           pendingAppWidgetId = appWidgetId // Track ID in case result strips it
           bindWidgetLauncher.launch(intent)
@@ -507,8 +514,15 @@ class MainActivity : ComponentActivity(), KeyShortcutHost, PipCapable {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     appWidgetManager = android.appwidget.AppWidgetManager.getInstance(applicationContext)
-    appWidgetHost =
-      android.appwidget.AppWidgetHost(applicationContext, WidgetRepository.APPWIDGET_HOST_ID)
+    appWidgetHost = LauncherAppWidgetHost(applicationContext, WidgetRepository.APPWIDGET_HOST_ID)
+    // Collection widgets bind their list adapters while createView applies RemoteViews. Listening
+    // must already be on before setContent hosts those views, or the first notify is dropped and
+    // multi-line widgets stay empty until a later size change happens to refresh them.
+    try {
+      appWidgetHost.startListening()
+    } catch (e: Exception) {
+      android.util.Log.e("MainActivity", "Failed to start widget host listening: ${e.message}")
+    }
     queryState = savedInstanceState?.getString(KEY_ACTIVE_QUERY) ?: restoreRecentQuery()
     enableEdgeToEdge()
     Ime.applyHomeWindowMode(window, HomeKeyboardPreference.cached(this))

--- a/app/src/main/java/com/searchlauncher/app/ui/WidgetHostViewFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/WidgetHostViewFactory.kt
@@ -1,13 +1,21 @@
 package com.searchlauncher.app.ui
 
 import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetManager
 import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.util.SizeF
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AdapterView
 import android.widget.FrameLayout
+import com.searchlauncher.app.data.WidgetRepository
+import java.util.WeakHashMap
 
 object WidgetHostViewFactory {
+  private val lastReportedSize = WeakHashMap<AppWidgetHostView, Pair<Int, Int>>()
   /**
    * Whether [appWidgetId] still names a widget this host can draw.
    *
@@ -24,6 +32,39 @@ object WidgetHostViewFactory {
       false
     }
 
+  /**
+   * Size options to store on a newly bound widget before its first layout.
+   *
+   * Collection providers (list/grid) measure item RemoteViews from
+   * [AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH] / `MAX_HEIGHT`. Leaving those at 0 — the default
+   * until the view is laid out — produces empty rows. Android 12+ also needs a non-empty
+   * [AppWidgetManager.OPTION_APPWIDGET_SIZES] list; the deprecated four-int
+   * [AppWidgetHostView.updateAppWidgetSize] call writes an empty list and responsive layouts then
+   * refuse to apply.
+   */
+  fun sizeOptions(widthDp: Int, heightDp: Int): Bundle {
+    val width = widthDp.coerceAtLeast(1)
+    val height = heightDp.coerceAtLeast(1)
+    val options = Bundle()
+    options.putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, width)
+    options.putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, width)
+    options.putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, height)
+    options.putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, height)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      options.putParcelableArrayList(
+        AppWidgetManager.OPTION_APPWIDGET_SIZES,
+        arrayListOf(SizeF(width.toFloat(), height.toFloat())),
+      )
+    }
+    return options
+  }
+
+  fun defaultSizeOptions(context: Context): Bundle {
+    val density = context.resources.displayMetrics.density
+    val widthDp = (context.resources.displayMetrics.widthPixels / density).toInt() - 32
+    return sizeOptions(widthDp.coerceAtLeast(1), WidgetRepository.DEFAULT_WIDGET_HEIGHT_DP)
+  }
+
   fun createWidgetView(
     context: Context,
     appWidgetId: Int,
@@ -34,22 +75,12 @@ object WidgetHostViewFactory {
       val appWidgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId) ?: return View(context)
       val hostView = appWidgetHost.createView(context, appWidgetId, appWidgetInfo)
       hostView.setAppWidget(appWidgetId, appWidgetInfo)
+      hostView.clipChildren = false
+      hostView.clipToPadding = false
 
       // Responsive/list providers need the actual allocated size, including after a resize.
       // Post outside layout and coalesce changes so provider updates cannot re-enter measurement.
-      var reportedSize: Pair<Int, Int>? = null
-      val reportSize = Runnable {
-        val density = hostView.resources.displayMetrics.density
-        val size = (hostView.width / density).toInt() to (hostView.height / density).toInt()
-        if (size.first > 0 && size.second > 0 && size != reportedSize) {
-          try {
-            hostView.updateAppWidgetSize(null, size.first, size.second, size.first, size.second)
-            reportedSize = size
-          } catch (e: Exception) {
-            android.util.Log.w("WidgetHostViewFactory", "Cannot report widget $appWidgetId size", e)
-          }
-        }
-      }
+      val reportSize = Runnable { reportAllocatedSize(hostView, appWidgetManager, appWidgetId) }
       hostView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
         hostView.removeCallbacks(reportSize)
         hostView.post(reportSize)
@@ -65,6 +96,8 @@ object WidgetHostViewFactory {
 
       // Wrap in a FrameLayout for layout params or padding if needed
       val frameLayout = FrameLayout(context)
+      frameLayout.clipChildren = false
+      frameLayout.clipToPadding = false
       frameLayout.addView(
         hostView,
         FrameLayout.LayoutParams(
@@ -79,6 +112,115 @@ object WidgetHostViewFactory {
       errorView.setBackgroundColor(android.graphics.Color.RED)
       errorView.layoutParams = ViewGroup.LayoutParams(100, 100)
       errorView
+    }
+  }
+
+  /**
+   * Pushes [container]'s laid-out pixel size to the hosted [AppWidgetHostView], if any.
+   *
+   * Compose knows the allocated box before the host view's own layout listener runs, which is when
+   * collection adapters first ask for item RemoteViews.
+   */
+  fun reportContainerSize(
+    container: ViewGroup,
+    appWidgetManager: AppWidgetManager,
+    widthPx: Int,
+    heightPx: Int,
+  ) {
+    val hostView = findHostView(container) ?: return
+    reportAllocatedSize(hostView, appWidgetManager, hostView.appWidgetId, widthPx, heightPx)
+  }
+
+  internal fun reportAllocatedSize(
+    hostView: AppWidgetHostView,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+    widthPx: Int = hostView.width,
+    heightPx: Int = hostView.height,
+  ): Pair<Int, Int>? {
+    val density = hostView.resources.displayMetrics.density
+    val resolvedWidth =
+      widthPx.takeIf { it > 0 }
+        ?: hostView.width.takeIf { it > 0 }
+        ?: (hostView.parent as? View)?.width
+        ?: 0
+    val resolvedHeight =
+      heightPx.takeIf { it > 0 }
+        ?: hostView.height.takeIf { it > 0 }
+        ?: (hostView.parent as? View)?.height
+        ?: 0
+    val size = (resolvedWidth / density).toInt() to (resolvedHeight / density).toInt()
+    if (size.first <= 0 || size.second <= 0 || size == lastReportedSize[hostView])
+      return lastReportedSize[hostView]
+    try {
+      val options =
+        try {
+          appWidgetManager.getAppWidgetOptions(appWidgetId) ?: Bundle()
+        } catch (_: Exception) {
+          Bundle()
+        }
+      options.putAll(sizeOptions(size.first, size.second))
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        hostView.updateAppWidgetSize(
+          options,
+          listOf(SizeF(size.first.toFloat(), size.second.toFloat())),
+        )
+      } else {
+        @Suppress("DEPRECATION")
+        hostView.updateAppWidgetSize(options, size.first, size.second, size.first, size.second)
+      }
+      lastReportedSize[hostView] = size
+      refreshCollectionAdapters(hostView, appWidgetManager, appWidgetId)
+    } catch (e: Exception) {
+      android.util.Log.w("WidgetHostViewFactory", "Cannot report widget $appWidgetId size", e)
+      return lastReportedSize[hostView]
+    }
+    return size
+  }
+
+  internal fun findHostView(container: ViewGroup): AppWidgetHostView? {
+    if (container is AppWidgetHostView) return container
+    for (i in 0 until container.childCount) {
+      when (val child = container.getChildAt(i)) {
+        is AppWidgetHostView -> return child
+        is ViewGroup ->
+          findHostView(child)?.let {
+            return it
+          }
+      }
+    }
+    return null
+  }
+
+  /**
+   * Collection widgets bind their RemoteViewsService when first inflated, often at 0×0. After the
+   * host has a real size, tell each AdapterView to reload so list items are measured against the
+   * reported dp rather than staying empty.
+   */
+  internal fun refreshCollectionAdapters(
+    hostView: AppWidgetHostView,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+  ) {
+    val viewIds = linkedSetOf<Int>()
+    fun walk(view: View) {
+      if (view is AdapterView<*> && view.id != View.NO_ID) viewIds += view.id
+      if (view is ViewGroup) {
+        for (i in 0 until view.childCount) walk(view.getChildAt(i))
+      }
+    }
+    walk(hostView)
+    viewIds.forEach { viewId ->
+      try {
+        @Suppress("DEPRECATION")
+        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, viewId)
+      } catch (e: Exception) {
+        android.util.Log.w(
+          "WidgetHostViewFactory",
+          "Cannot refresh collection $viewId on widget $appWidgetId",
+          e,
+        )
+      }
     }
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/WallpaperBackground.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.zIndex
 import androidx.datastore.preferences.core.edit
 import coil.compose.AsyncImage
 import com.searchlauncher.app.data.WidgetData
+import com.searchlauncher.app.data.WidgetRepository
 import com.searchlauncher.app.ui.MainActivity
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.WidgetHostViewFactory
@@ -396,8 +397,19 @@ fun WallpaperBackground(
                       class WidgetContainerView(context: android.content.Context) :
                         android.widget.FrameLayout(context) {
                         init {
-                          clipChildren = true
-                          clipToPadding = true
+                          clipChildren = false
+                          clipToPadding = false
+                        }
+
+                        override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+                          super.onSizeChanged(w, h, oldw, oldh)
+                          val activity = context as? MainActivity ?: return
+                          WidgetHostViewFactory.reportContainerSize(
+                            this,
+                            activity.appWidgetManager,
+                            w,
+                            h,
+                          )
                         }
 
                         private var onLongPressListener: (() -> Unit)? = null
@@ -690,7 +702,7 @@ private fun MissingWidget(
 private val WIDGET_COLUMN_MAX_WIDTH = 420.dp
 
 /** Height assumed for a widget that has never been resized, matching the default it is given. */
-private val WIDGET_DEFAULT_HEIGHT = 200.dp
+private val WIDGET_DEFAULT_HEIGHT = WidgetRepository.DEFAULT_WIDGET_HEIGHT_DP.dp
 
 /**
  * Gap between the widget list and the favorites / chrome block, matching the chrome column's own

--- a/app/src/test/java/com/searchlauncher/app/ui/WidgetHostViewFactoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/WidgetHostViewFactoryTest.kt
@@ -1,16 +1,22 @@
 package com.searchlauncher.app.ui
 
 import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
 import android.content.ComponentName
 import android.content.Context
+import android.os.Bundle
+import android.util.SizeF
 import android.view.ViewGroup
+import android.widget.ListView
 import androidx.test.core.app.ApplicationProvider
 import com.searchlauncher.app.SearchLauncherApp
+import com.searchlauncher.app.data.WidgetRepository
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -64,19 +70,26 @@ class WidgetHostViewFactoryTest {
 
   @Test
   @Config(qualifiers = "xxhdpi")
-  fun `allocated widget size is reported in dp and follows resizing`() {
+  fun `allocated widget size is reported as SizeF and follows resizing`() {
     bind(12, minHeight = 60)
     val sizes = mutableListOf<Pair<Int, Int>>()
+    val intApiCalls = mutableListOf<Pair<Int, Int>>()
     val widgetView =
-      object : android.appwidget.AppWidgetHostView(context) {
+      object : AppWidgetHostView(context) {
+        override fun updateAppWidgetSize(options: Bundle, sizesFromHost: List<SizeF>) {
+          val size = sizesFromHost.single()
+          sizes.add(size.width.toInt() to size.height.toInt())
+        }
+
+        @Deprecated("Deprecated in Java")
         override fun updateAppWidgetSize(
-          options: android.os.Bundle?,
+          options: Bundle?,
           minWidth: Int,
           minHeight: Int,
           maxWidth: Int,
           maxHeight: Int,
         ) {
-          sizes.add(minWidth to minHeight)
+          intApiCalls.add(minWidth to minHeight)
         }
       }
     val host = io.mockk.mockk<AppWidgetHost>()
@@ -96,6 +109,7 @@ class WidgetHostViewFactoryTest {
       shadowOf(android.os.Looper.getMainLooper()).idle()
     }
     layout(600)
+    assertTrue("Android 12+ must use SizeF sizes, not the four-int API", intApiCalls.isEmpty())
     val first = sizes.last().second
     assertTrue(first > 0)
     assertTrue(first <= 200)
@@ -103,6 +117,72 @@ class WidgetHostViewFactoryTest {
     val second = sizes.last().second
     assertEquals(100, second - first)
     activity.finish()
+  }
+
+  @Test
+  fun `size options include a non-empty Android 12 sizes list`() {
+    val options = WidgetHostViewFactory.sizeOptions(320, 200)
+    assertEquals(320, options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH))
+    assertEquals(320, options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH))
+    assertEquals(200, options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT))
+    assertEquals(200, options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT))
+    val sizes = options.getParcelableArrayList<SizeF>(AppWidgetManager.OPTION_APPWIDGET_SIZES)
+    assertNotNull(sizes)
+    assertEquals(1, sizes!!.size)
+    assertEquals(320f, sizes[0].width)
+    assertEquals(200f, sizes[0].height)
+  }
+
+  @Test
+  fun `default size options use the stored widget height`() {
+    val options = WidgetHostViewFactory.defaultSizeOptions(context)
+    assertEquals(
+      WidgetRepository.DEFAULT_WIDGET_HEIGHT_DP,
+      options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT),
+    )
+    val sizes = options.getParcelableArrayList<SizeF>(AppWidgetManager.OPTION_APPWIDGET_SIZES)
+    assertFalse(sizes.isNullOrEmpty())
+  }
+
+  @Test
+  @Config(qualifiers = "xxhdpi")
+  fun `container size is reported even before the host view lays itself out`() {
+    bind(14)
+    val sizes = mutableListOf<SizeF>()
+    val widgetView =
+      object : AppWidgetHostView(context) {
+        override fun updateAppWidgetSize(options: Bundle, sizesFromHost: List<SizeF>) {
+          sizes += sizesFromHost
+        }
+      }
+    val host = io.mockk.mockk<AppWidgetHost>()
+    io.mockk.every { host.createView(any(), 14, any()) } returns widgetView
+    val view =
+      WidgetHostViewFactory.createWidgetView(context, 14, host, appWidgetManager) as ViewGroup
+    WidgetHostViewFactory.reportContainerSize(view, appWidgetManager, 900, 600)
+    assertEquals(1, sizes.size)
+    val density = context.resources.displayMetrics.density
+    assertEquals((900 / density).toInt().toFloat(), sizes[0].width)
+    assertEquals((600 / density).toInt().toFloat(), sizes[0].height)
+  }
+
+  @Test
+  fun `collection adapters are asked to reload after a size is reported`() {
+    bind(15)
+    val list = ListView(context).apply { id = 42 }
+    val widgetView =
+      object : AppWidgetHostView(context) {
+        init {
+          addView(list, ViewGroup.LayoutParams(100, 100))
+        }
+
+        override fun updateAppWidgetSize(options: Bundle, sizesFromHost: List<SizeF>) {}
+      }
+    widgetView.layout(0, 0, 300, 200)
+    WidgetHostViewFactory.reportAllocatedSize(widgetView, appWidgetManager, 15, 300, 200)
+    // Robolectric delivers the notify; the point is that a ListView child is discovered and the
+    // call does not throw. A second report of the same size is coalesced.
+    WidgetHostViewFactory.reportAllocatedSize(widgetView, appWidgetManager, 15, 300, 200)
   }
 
   @Test
@@ -125,5 +205,12 @@ class WidgetHostViewFactoryTest {
 
     assertTrue(WidgetHostViewFactory.canRender(appWidgetManager, 7))
     assertFalse(WidgetHostViewFactory.canRender(appWidgetManager, 8))
+  }
+
+  @Test
+  fun `the launcher host view does not clip collection children`() {
+    val view = LauncherAppWidgetHostView(context)
+    assertFalse(view.clipChildren)
+    assertFalse(view.clipToPadding)
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #137.

The 0.0.38 hosting change (#139) made Smartspacer’s **single-line** widget work. The **multi-line / vertical list** widget (and similar collection widgets such as ToDo Agenda) still rendered as a blank box on 0.0.38/0.0.39.

## Cause

Those widgets are collection `ListView`s. They measure item `RemoteViews` from the host’s AppWidget options:

- `OPTION_APPWIDGET_MIN_WIDTH` / `MAX_HEIGHT` (Smartspacer)
- `OPTION_APPWIDGET_SIZES` on Android 12+

The deprecated four-int `updateAppWidgetSize` path **writes an empty `OPTION_APPWIDGET_SIZES` list**. Combined with the host starting to listen only after Compose had already created the views, the list adapter bound at 0×0 and never reloaded.

The single-line (paged) Smartspacer widget is ordinary `RemoteViews`, which is why it recovered in 0.0.38 while the list widget did not.

## Fix

- Report allocated size with the Android 12 `SizeF` API so `OPTION_APPWIDGET_SIZES` is a real list, not empty
- Store default width/height on bind so the first provider update is not 0×0
- Start `AppWidgetHost` listening in `onCreate` **before** `setContent` hosts widgets
- After layout, notify each hosted `AdapterView` to reload
- Do not clip collection children; push Compose’s allocated pixel size into the host as soon as the box exists

## Validation

- `./gradlew spotlessApply`, full `./gradlew test` (debug + release), `./gradlew assembleDebug`
- 10/10 `WidgetHostViewFactoryTest` cases passed, including SizeF resize reporting and a non-empty `OPTION_APPWIDGET_SIZES` list
- On the AOSP emulator, added the stock **Calendar** collection widget (same ListView hosting path as Smartspacer’s multi-line widget). It shows the date header and “No upcoming calendar events” instead of a blank box.

[Calendar list widget on SearchLauncher home](https://cursor.com/agents/bc-c96579a7-3361-405a-ab49-63ba5a461829/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_list_widget_on_home.png)

[calendar_list_widget_hosts_with_content.mp4](https://cursor.com/agents/bc-c96579a7-3361-405a-ab49-63ba5a461829/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_list_widget_hosts_with_content.mp4)

Smartspacer 1.11.3 is not on this emulator (AOSP 11, no Play Store), so the exact Moto Power / Android 15 vertical-list configuration from [the follow-up](https://github.com/ontola/searchlauncher/issues/137#issuecomment-5619275499) still needs a physical-device check.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c96579a7-3361-405a-ab49-63ba5a461829?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c96579a7-3361-405a-ab49-63ba5a461829&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

